### PR TITLE
Fn-powered truly-serverless apps with functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,12 +139,12 @@ class Application(object):
     def __init__(self, *args, **kwargs):
         pass
 
-    @decorators.fn_route(fn_image="denismakogon/os.environ:latest")
+    @decorators.with_fn(fn_image="denismakogon/os.environ:latest")
     def env(self, fn_data=None):
         return fn_data
 
-    @decorators.fn_route(fn_image="denismakogon/py-traceback-test:0.0.1",
-                         fn_format="http")
+    @decorators.with_fn(fn_image="denismakogon/py-traceback-test:0.0.1",
+                        fn_format="http")
     def traceback(self, fn_data=None):
         return fn_data
 
@@ -191,8 +191,8 @@ Applications powered by Fn: working with function's result
 
 In order to work with result from function you just need to read key-value argument `fn_data`:
 ```python
-    @decorators.fn_route(fn_image="denismakogon/py-traceback-test:0.0.1",
-                         fn_format="http")
+    @decorators.with_fn(fn_image="denismakogon/py-traceback-test:0.0.1",
+                        fn_format="http")
     def traceback(self, fn_data=None):
         return fn_data
 ```

--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ FDK is not only about developing functions, but providing necessary API to build
 that look like nothing but classes with methods powered by Fn.
 
 ```python
+import requests
+
 from fdk.application import decorators
 
 
@@ -148,6 +150,19 @@ class Application(object):
     def traceback(self, fn_data=None):
         return fn_data
 
+    @decorators.fn(fn_type="sync")
+    def square(self, x, y, *args, **kwargs):
+        return x * y
+
+    @decorators.fn(fn_type="sync", dependencies={
+        "requests_get": requests.get
+    })
+    def request(self, *args, **kwargs):
+        requests_get = kwargs["dependencies"].get("requests_get")
+        r = requests_get('https://api.github.com/events')
+        r.raise_for_status()
+        return r.text
+
 if __name__ == "__main__":
     app = Application(config={})
 
@@ -157,6 +172,16 @@ if __name__ == "__main__":
     print(res)
 
     res, err = app.traceback()
+    if err:
+        raise err
+    print(res)
+
+    res, err = app.square(10, 20)
+    if err:
+        raise err
+    print(res)
+
+    res, err = app.request()
     if err:
         raise err
     print(res)
@@ -196,6 +221,39 @@ In order to work with result from function you just need to read key-value argum
     def traceback(self, fn_data=None):
         return fn_data
 ```
+
+Applications powered by Fn: advanced serverless functions
+---------------------------------------------------------
+
+Since release v0.0.3 developer can consume new API to build truly serverless functions 
+without taking care of Docker images, application, etc.
+
+```python
+    @decorators.fn(fn_type="sync")
+    def square(self, x, y, *args, **kwargs):
+        return x * y
+
+    @decorators.fn(fn_type="sync", dependencies={
+        "requests_get": requests.get
+    })
+    def request(self, *args, **kwargs):
+        requests_get = kwargs["dependencies"].get("requests_get")
+        r = requests_get('https://api.github.com/events')
+        r.raise_for_status()
+        return r.text
+```
+
+Each function decorated with `@decorator.fn` will become truly serverless and distributed.
+So, how it works?
+
+    * A developer writes function
+    * FDK (Fn-powered app) creates a recursive Pickle v4.0 with 3rd-party dependencies
+    * FDK (Fn-powered app) transfers pickled object to a function based on Python3 GPI (general purpose image)
+    * FDK unpickles function and its 3rd-party dependencies and runs it
+    * Function sends response back to Fn-powered application function caller
+
+So, each CPU-intensive functions can be sent to Fn with the only load on networking (given example creates 7kB of traffic between app's host and Fn).
+
 
 Applications powered by Fn: exceptions
 --------------------------------------

--- a/fdk/tests/test_application.py
+++ b/fdk/tests/test_application.py
@@ -12,7 +12,12 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import os
+import requests
+import testtools
+
 from fdk.application import decorators
+from fdk.application import errors
 
 
 @decorators.fn_app
@@ -21,25 +26,82 @@ class Application(object):
     def __init__(self, *args, **kwargs):
         pass
 
-    @decorators.fn_route(fn_image="denismakogon/os.environ:latest")
+    @decorators.with_fn(fn_image="denismakogon/os.environ:latest")
     def env(self, fn_data=None):
         return fn_data
 
-    @decorators.fn_route(fn_image="denismakogon/py-traceback-test:0.0.1",
-                         fn_format="http")
+    @decorators.with_fn(fn_image="denismakogon/py-traceback-test:0.0.1",
+                        fn_format="http")
     def traceback(self, fn_data=None):
         return fn_data
 
+    @decorators.fn(fn_type="sync")
+    def square(self, x, y, *args, **kwargs):
+        return x * y
 
+    @decorators.fn(fn_type="sync", dependencies={
+        "requests_get": requests.get
+    })
+    def request(self, *args, **kwargs):
+        requests_get = kwargs["dependencies"].get("requests_get")
+        r = requests_get('https://api.github.com/events')
+        r.raise_for_status()
+        return r.text
+
+
+class TestApplication(testtools.TestCase):
+
+    @testtools.skipIf(os.getenv("API_URL") is None,
+                      "API_URL is not set")
+    def test_can_call_with_fn(self):
+        app = Application(config={})
+        res, err = app.env()
+        self.assertIsNone(err, message=str(err))
+
+    @testtools.skipIf(os.getenv("API_URL") is None,
+                      "API_URL is not set")
+    def test_can_get_traceback(self):
+        app = Application(config={})
+        res, err = app.traceback()
+        self.assertIsNotNone(err, message=str(err))
+        self.assertIsInstance(err, errors.FnError)
+
+    # @testtools.skipIf(os.getenv("API_URL") is None,
+    #                   "API_URL is not set")
+    # def test_can_call_fn_simple(self):
+    #     app = Application(config={})
+    #     res, err = app.square(10, 20)
+    #     self.assertIsNone(err, message=str(err))
+    #     self.assertEqual(int(res), 10 * 20)
+    #
+    # @testtools.skipIf(os.getenv("API_URL") is None,
+    #                   "API_URL is not set")
+    # def test_can_call_fn_with_deps(self):
+    #     app = Application(config={})
+    #     res, err = app.request()
+    #     self.assertIsNone(err, message=str(err))
+    #     self.assertNotNone(res)
+
+
+# NOTE: somehow dill pickler doesn't work fine in tests,
+# it gives pretty weird error:
+# _pickle.PicklingError: Can't pickle
+# <class 'fdk.tests.test_application.Application'>:
+# it's not the same object as fdk.tests.test_application.Application
+#
+# That why this module should be tested separately as CLI script
 if __name__ == "__main__":
-    app = Application(config={})
+    if os.getenv("API_URL") is not None:
+        app = Application(config={})
 
-    res, err = app.env()
-    if err:
-        raise err
-    print(res)
+        res, err = app.square(10, 20)
+        if err:
+            raise err
+        print(res)
 
-    res, err = app.traceback()
-    if err:
-        raise err
-    print(res)
+        res, err = app.request()
+        if err:
+            raise err
+        print(res)
+    else:
+        print("API_URL not test, skipping...")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pbr!=2.1.0,>=2.0.0 # Apache-2.0
 ujson==1.35
 requests==2.18.4
+dill==0.2.7.1

--- a/samples/python3-fn-gpi/Dockerfile
+++ b/samples/python3-fn-gpi/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.6.2
+
+RUN mkdir /code
+ADD . /code/
+WORKDIR /code/
+RUN pip install -r requirements.txt
+
+ENTRYPOINT ["python3", "func.py"]

--- a/samples/python3-fn-gpi/func.py
+++ b/samples/python3-fn-gpi/func.py
@@ -1,0 +1,115 @@
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import asyncio
+import dill
+import fdk
+import json
+import sys
+
+from fdk.http import response
+
+
+async def handler(context, data=None, loop=None):
+    """
+    General purpose Python3 function processor
+
+    Why general purpose?
+
+     - It supports any call from Fn-powered Python applications
+       that utilizes corresponding API to run
+       distributed Python functions
+
+    How is it different from other Python FDK functions?
+
+     - This function works with serialized Python callable objects via wire.
+       Each function supplied with set of external dependencies that are
+       represented as serialized functions, no matter if they are module-level,
+       class-level Python objects
+
+    :param context: request context
+    :type context: fdk.context.RequestContext
+    :param data: request data
+    :type data: fdk.http.request.ContentLengthStream
+    :param loop: asyncio event loop
+    :type loop: asyncio.AbstractEventLoop
+    :return: resulting object of distributed function
+    :rtype: object
+    """
+    action_dict = json.loads(data.read())
+    (is_coroutine, self_in_bytes,
+     action_in_bytes, action_args, action_kwargs) = (
+        action_dict['is_coroutine'],
+        action_dict['self'],
+        action_dict['action'],
+        action_dict['args'],
+        action_dict['kwargs'])
+
+    print("Got {} bytes of class instance".format(len(self_in_bytes)),
+          file=sys.stderr, flush=True)
+    print("Got {} bytes of function".format(len(action_in_bytes)),
+          file=sys.stderr, flush=True)
+
+    print("string class instance unpickling",
+          file=sys.stderr, flush=True)
+    self = dill.loads(bytes(self_in_bytes))
+    print("class instance unpickled, type: ", type(self),
+          file=sys.stderr, flush=True)
+    print("string class instance function unpickling",
+          file=sys.stderr, flush=True)
+    action = dill.loads(bytes(action_in_bytes))
+    print("class instance function unpickled, type: ",
+          type(action), file=sys.stderr, flush=True)
+
+    action_args.insert(0, self)
+
+    dependencies = action_kwargs.get("dependencies", {})
+    print("cached external methods found: ", len(dependencies) > 0,
+          file=sys.stderr, flush=True)
+    for name, method_in_bytes in dependencies.items():
+        dependencies[name] = dill.loads(bytes(method_in_bytes))
+
+    action_kwargs["dependencies"] = dependencies
+
+    print("cached dependencies unpickled", file=sys.stderr, flush=True)
+
+    try:
+        res = action(*action_args, **action_kwargs)
+    except Exception as ex:
+        print("call failed", file=sys.stderr, flush=True)
+        return response.RawResponse(
+            http_proto_version=context.version,
+            status_code=500,
+            headers={
+                "Content-Type": "text/plain",
+            },
+            response_data=str(ex))
+
+    print("call result: {}".format(res), file=sys.stderr, flush=True)
+
+    if is_coroutine:
+        res = await res
+
+    return response.RawResponse(
+        http_proto_version=context.version,
+        status_code=200,
+        headers={
+            "Content-Type": "text/plain",
+        },
+        response_data=dill.dumps(res))
+
+
+if __name__ == "__main__":
+    loop = asyncio.get_event_loop()
+    fdk.handle(handler, loop=loop)

--- a/samples/python3-fn-gpi/func.yaml
+++ b/samples/python3-fn-gpi/func.yaml
@@ -1,0 +1,7 @@
+name: denismakogon/python3-fn-gpi:0.0.1
+version: 0.0.1
+runtime: docker
+type: sync
+memory: 256
+format: http
+path: /python3-fn-gpi

--- a/samples/python3-fn-gpi/requirements.txt
+++ b/samples/python3-fn-gpi/requirements.txt
@@ -1,0 +1,3 @@
+fdk==0.0.2
+cloudpickle==0.4.0
+dill==0.2.7.1

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ basepython =
 
 passenv =
         DOCKER_HOST
+        API_URL
 setenv = VIRTUAL_ENV={envdir}
 usedevelop = True
 install_command = pip install -U {opts} {packages}


### PR DESCRIPTION
What's new?

The most awesome thing! Since v0.0.3 developers will be capable to run Python functions without actually building images - just write function and it will be handled gracefully by Fn.

How does it work?
```
 A developer writes function ----> 
 ----> FDK (Fn-powered app) creates a recursive Pickle v4.0 with 3rd-party dependencies ----> 
 ----> FDK (Fn-powered app) transfers pickled object to a function based on Python3 GPI (general purpose image) ----> 
 ----> FDK unpickles function and its 3rd-party dependencies and runs it ---->
 ----> Function sends response back to Fn-powered application function caller
```

![](https://res.cloudinary.com/teepublic/image/private/s--bAGLHIGo--/t_Preview/b_rgb:ffffff,c_limit,f_jpg,h_630,q_90,w_630/v1502240394/production/designs/1803286_2.jpg)
