### PR TITLE
Improvement: make FDK return valid raw XML/HTML content

### DIFF
--- a/fdk/context.py
+++ b/fdk/context.py
@@ -170,8 +170,9 @@ def context_from_format(format_def, stream) -> (RequestContext, object):
             "request_url": "http://localhost:8080/r/{0}{1}".format(app, path),
         })
         json_headers = headers.GoLikeHeaders(protocol.get("headers"))
-        data = incoming_request.get("data", "{}")
-        del incoming_request["data"]
+        data = incoming_request.get("data")
+        if "data" in incoming_request:
+            del incoming_request["data"]
 
         ctx = CloudEventContext(
             app, path, call_id,

--- a/fdk/response.py
+++ b/fdk/response.py
@@ -17,6 +17,31 @@ import sys
 
 from fdk import headers as hrs
 
+APP_JSON = "application/json"
+
+
+def setup_data(response_data, headers):
+    content_type = headers.get(
+        "content-type",
+        default=APP_JSON
+    )
+    # if response data is an HTML data JSON
+    # decoding will make it malformed
+    # so, we need to tread data with
+    # respect according to content type header
+
+    if content_type.startswith(APP_JSON):
+        # dump to JSON only in case of explicitly declared type
+        data = ujson.dumps(response_data)
+    else:
+        # any other type like HTML/XML must
+        # be returned as native strings
+        # JSON-encoded HTML/XML would be recognized
+        # by modern browsers as a string
+        data = response_data
+
+    return data
+
 
 class JSONResponse(object):
 
@@ -24,6 +49,8 @@ class JSONResponse(object):
                  headers=None, status_code=200):
         """
         JSON response object
+        :param context: request context
+        :type context: fdk.context.JSONContext
         :param response_data: response data (any JSON-serializable object)
         :type response_data: object
         :param headers: JSON response HTTP headers
@@ -44,12 +71,13 @@ class JSONResponse(object):
         Dumps raw JSON response to a stream
         :return: result of dumping
         """
-        json_data = ujson.dumps(self.response_data)
-        self.headers.set("content-length", len(json_data))
+        content_type, data = setup_data(
+            self.response_data, self.headers)
+
+        self.headers.set("content-length", len(data))
         resp = ujson.dumps({
-            "body": json_data,
-            "content_type": self.headers.get(
-                "content-type", default="application/json"),
+            "body": data,
+            "content_type": content_type,
             "protocol": {
                 "status_code": self.status_code,
                 "headers": self.headers.for_dump()
@@ -70,6 +98,8 @@ class CloudEventResponse(object):
                  headers=None, status_code=200):
         """
         CloudEvent response object
+        :param context: request context
+        :type context: fdk.context.CloudEventContext
         :param response_data: response data (any JSON-serializable object)
         :type response_data: object
         :param headers: JSON response HTTP headers
@@ -92,12 +122,13 @@ class CloudEventResponse(object):
         Dumps raw JSON response to a stream
         :return: result of dumping
         """
-        json_data = ujson.dumps(self.response_data)
-        self.headers.set("content-length", len(json_data))
+        content_type, data = setup_data(
+            self.response_data, self.headers)
+
+        self.headers.set("content-length", len(data))
         ce = self.cloudevent
-        ce["contentType"] = self.headers.get(
-            "content-type", default="text/plain")
-        ce["data"] = json_data
+        ce["contentType"] = content_type
+        ce["data"] = data
         ce["extensions"] = {
             "protocol": {
                 "status_code": self.status_code,

--- a/fdk/response.py
+++ b/fdk/response.py
@@ -40,7 +40,7 @@ def setup_data(response_data, headers):
         # by modern browsers as a string
         data = response_data
 
-    return data
+    return content_type, data
 
 
 class JSONResponse(object):

--- a/fdk/tests/funcs.py
+++ b/fdk/tests/funcs.py
@@ -18,6 +18,18 @@ import ujson
 from fdk import response
 
 
+xml = """<!DOCTYPE mensaje SYSTEM "record.dtd">
+<record>
+    <player_birthday>1979-09-23</player_birthday>
+    <player_name>Orene Ai'i</player_name>
+    <player_team>Blues</player_team>
+    <player_id>453</player_id>
+    <player_height>170</player_height>
+    <player_position>FW</player_position>
+    <player_weight>75</player_weight>
+</record>"""
+
+
 def dummy_func(ctx, data=None):
     body = ujson.loads(data) if len(data) > 0 else {"name": "World"}
     return "Hello {0}".format(body.get("name"))
@@ -52,3 +64,19 @@ def timed_sleepr(timeout):
 
 async def coro(ctx, **kwargs):
     return "hello from coro"
+
+
+def valid_xml(ctx, **kwargs):
+    return response.RawResponse(
+        ctx, response_data=xml, headers={
+            "content-type": "application/xml",
+        }
+    )
+
+
+def invalid_xml(ctx, **kwargs):
+    return response.RawResponse(
+        ctx, response_data=ujson.dumps(xml), headers={
+            "content-type": "application/xml",
+        }
+    )

--- a/fdk/tests/mixin.py
+++ b/fdk/tests/mixin.py
@@ -17,6 +17,8 @@ from fdk import runner
 
 from fdk.tests import funcs
 
+from xml.etree import ElementTree
+
 
 class Mixin(object):
 
@@ -104,3 +106,22 @@ class Mixin(object):
         self.assertEqual(502, r.status())
         self.assertIn("function timed out",
                       r.body()["error"]["message"])
+
+    def xml_successful_verification(self, income_data):
+        r = runner.from_request(
+            funcs.valid_xml, income_data, self.format_def)
+        r = self.loop.run_until_complete(r)
+        # this should not raise an error
+        ElementTree.fromstring(r.body())
+        h = r.headers()
+        self.assertEqual(h.get("content-type"), "application/xml")
+
+    def xml_unsuccessful_verification(self, income_data):
+        r = runner.from_request(
+            funcs.invalid_xml, income_data, self.format_def)
+        r = self.loop.run_until_complete(r)
+        # this should raise an error
+        self.assertRaises(
+            ElementTree.ParseError,
+            ElementTree.fromstring, r.body()
+        )

--- a/fdk/tests/test_cloudevent.py
+++ b/fdk/tests/test_cloudevent.py
@@ -78,3 +78,13 @@ class TestCloudEventRequestParser(mixin.Mixin, testtools.TestCase):
         timeout_data = data.cloudevent_request_with_body.copy()
         timeout_data["extensions"]["deadline"] = None
         self.default_deadline(data.to_stream(timeout_data))
+
+    def test_valid_xml(self):
+        income_data = data.to_stream(
+            data.cloudevent_request_without_body)
+        self.xml_successful_verification(income_data)
+
+    def test_invalid_xml(self):
+        income_data = data.to_stream(
+            data.cloudevent_request_without_body)
+        self.xml_unsuccessful_verification(income_data)

--- a/fdk/tests/test_json.py
+++ b/fdk/tests/test_json.py
@@ -74,7 +74,12 @@ class TestJSONRequestParser(mixin.Mixin, testtools.TestCase):
         timeout_data["deadline"] = now.isoformat()
         self.deadline(timeout, data.to_stream(timeout_data))
 
-    def test_default_deadline(self):
-        timeout_data = data.json_request_with_body.copy()
-        timeout_data["deadline"] = None
-        self.default_deadline(data.to_stream(timeout_data))
+    def test_valid_xml(self):
+        income_data = data.to_stream(
+            data.json_request_without_body)
+        self.xml_successful_verification(income_data)
+
+    def test_invalid_xml(self):
+        income_data = data.to_stream(
+            data.json_request_without_body)
+        self.xml_unsuccessful_verification(income_data)


### PR DESCRIPTION
 at this moment FDK tried to JSONify whatever a function returns,
 unfortunately it doesn't work for XML/HTML content, so, the response
 dumper should take care of the response data with respect to its content type