### PR TITLE
Moving docker images to FDK repo as officially supported

### DIFF
--- a/images/README.md
+++ b/images/README.md
@@ -1,0 +1,21 @@
+Image on Docker Hub: https://hub.docker.com/r/fnproject/python
+
+## Building Python images
+
+```sh
+pushd build/3.6; docker build -t fnproject/python:3.6-dev .; popd
+pushd build/3.7; docker build -t fnproject/python:3.7-dev .; popd
+
+pushd runtime/3.6; docker build -t fnproject/python:3.6 .; popd
+pushd runtime/3.7; docker build -t fnproject/python:3.7 .; popd
+```
+
+Then push:
+
+```sh
+docker push fnproject/python:3.6-dev
+docker push fnproject/python:3.6
+
+docker push fnproject/python:3.7-dev
+docker push fnproject/python:3.7
+```

--- a/images/runtime/3.6/Dockerfile
+++ b/images/runtime/3.6/Dockerfile
@@ -1,0 +1,1 @@
+FROM python:3.6-slim-stretch

--- a/images/runtime/3.7/Dockerfile
+++ b/images/runtime/3.7/Dockerfile
@@ -1,0 +1,1 @@
+FROM python:3.7-slim-stretch


### PR DESCRIPTION
 - easier to find
 - new 3.7 version added
 - ready for multistage