### PR TITLE
Feature: unittest your function

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,54 @@
+<!--
+If you are reporting a new issue, make sure that we do not have any duplicates
+already open. You can ensure this by searching the issue list for this
+repository. If there is a duplicate, please close your issue and add a comment
+to the existing issue instead.
+
+If you suspect your issue is a bug, please edit your issue description to
+include the BUG REPORT INFORMATION shown below. If you fail to provide this
+information within 7 days, we cannot debug your issue and will close it. We
+will, however, reopen it if you later provide the information.
+
+---------------------------------------------------
+GENERAL SUPPORT INFORMATION
+---------------------------------------------------
+
+The GitHub issue tracker is for bug reports and feature requests.
+General support for **fn** can be found at the following locations:
+
+- Slack - https://fnproject.slack.com #general channel
+- Post a question on StackOverflow, using the ‘fn' tag: https://stackoverflow.com/questions/tagged/fn
+
+---------------------------------------------------
+BUG REPORT INFORMATION
+---------------------------------------------------
+Use the commands below to provide key information from your environment:
+You do NOT have to include this information if this is a FEATURE REQUEST
+-->
+
+**Description**
+
+<!--
+Briefly describe the problem you are having in a few paragraphs.
+-->
+
+**Steps to reproduce the issue:**
+1.
+2.
+3.
+
+**Describe the results you received:**
+
+
+**Describe the results you expected:**
+
+
+**Additional information you deem important (e.g. issue happens only occasionally):**
+
+**Output of `FDK version` (PIP output):**
+
+```
+(paste your output here)
+```
+
+**Additional environment details (python version, code sample, etc.):**

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+- Link to issue this resolves
+
+- What I did
+
+- How I did it
+
+- How to verify it
+
+- One line description for the changelog
+
+- One moving picture involving robots (not mandatory but encouraged)

--- a/README.md
+++ b/README.md
@@ -24,6 +24,83 @@ if __name__ == "__main__":
 
 ```
 
+Unittest your functions
+--------------------------
+
+As you may be aware [Fn CLI](https://github.com/fnproject/cli) offers a very first compatibility barrier between your code and Fn server 
+by allowing developers to perform black-box testing using the following CLI call with a function's folder:
+```bash
+fn test
+```
+
+This CLI call depends on `test.json` file that contains an input and the output data for the black-box testing.
+
+Starting v0.0.33 FDK-Python provides a testing framework that allows to perform unit tests of your function's code.
+The framework is an extension to [testtools](https://testtools.readthedocs.io/en/latest/) testing framework, coding style remain the same, so, write your tests as you've got used to.
+Here's the example of the test suite:
+```python
+from fdk import fixtures
+from fdk.tests import funcs
+
+
+class TestFuncToTest(fixtures.FunctionTestCase):
+
+    content = "OK"
+
+    def setUp(self):
+        super(TestFuncToTest, self).setUp(
+            self.content, funcs.content_type)
+
+    def tearDown(self):
+        super(TestFuncToTest, self).tearDown()
+
+    def test_response_data(self):
+        self.assertResponseConsistent(
+            lambda x: x == self.content,
+            message="content must be equal to '{0}'"
+            .format(self.content)
+        )
+
+    def test_response_header_presence(self):
+        self.assertInHeaders(
+            "content-type",
+            message="header 'content-type' "
+                    "must be present in headers")
+
+    def test_response_header_value(self):
+        self.assertInHeaders(
+            "content-type", value='application/xml',
+            message="header 'content-type' "
+                    "must be present in headers with the exact value")
+
+```
+
+As you may see, the framework provides new assertion methods like:
+
+ * assertInHeaders - allows to assert header(s) presence in response
+ * assertInTime - allows to assert the time necessary for a function to finish
+ * assertNotInTime - allows to assert the time within a function was not able to finish
+ * assertResponseConsistent - allows to assert function's response content consistency by accepting a callable object that must return boolean value that states the consistency
+
+
+In order to run tests, use the following command:
+```bash
+pytest -v -s --tb=long <your-function's-folder-with-tests>
+```
+
+To add coverage first install one more package:
+```bash
+pip install pytest-cov
+```
+then run tests with coverage flag:
+```bash
+pytest -v -s --tb=long --cov=<your-function's-package> <your-function's-folder-with-tests>
+```
+
+
+If you'd like to add more assertions to an upstream - please open an issue.
+
+
 Applications powered by Fn: Concept
 -----------------------------------
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ fn test
 
 This CLI call depends on `test.json` file that contains an input and the output data for the black-box testing.
 
-Starting v0.0.33 FDK-Python provides a testing framework that allows to perform unit tests of your function's code.
+Starting v0.0.33 FDK-Python provides a testing framework that allows performing unit tests of your function's code.
 The framework is an extension to [testtools](https://testtools.readthedocs.io/en/latest/) testing framework, coding style remain the same, so, write your tests as you've got used to.
 Here's the example of the test suite:
 ```python
@@ -77,10 +77,10 @@ class TestFuncToTest(fixtures.FunctionTestCase):
 
 As you may see, the framework provides new assertion methods like:
 
- * assertInHeaders - allows to assert header(s) presence in response
- * assertInTime - allows to assert the time necessary for a function to finish
- * assertNotInTime - allows to assert the time within a function was not able to finish
- * assertResponseConsistent - allows to assert function's response content consistency by accepting a callable object that must return boolean value that states the consistency
+ * assertInHeaders - allows asserting header(s) presence in response
+ * assertInTime - allows asserting the time necessary for a function to finish
+ * assertNotInTime - allows asserting the time within a function was not able to finish
+ * assertResponseConsistent - allows asserting function's response content consistency by accepting a callable object that must return a boolean value that states the consistency
 
 
 In order to run tests, use the following command:

--- a/fdk/fixtures.py
+++ b/fdk/fixtures.py
@@ -1,0 +1,161 @@
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import asyncio
+import io
+import os
+import uuid
+import ujson
+import testtools
+import datetime as dt
+
+from fdk import runner
+
+
+class FunctionTestCase(testtools.TestCase):
+
+    def setUp(self, request_data: object, func, fn_format: str="json"):
+        self.fn_format = fn_format
+        self.__protocol_frame = self.setup_protocol_frame(request_data)
+        self.setup_environment()
+        self.__func = func
+        self.__func_data = request_data
+        self.loop = asyncio.new_event_loop()
+        super(FunctionTestCase, self).setUp()
+
+    def tearDown(self):
+        self.loop.close()
+        super(FunctionTestCase, self).tearDown()
+
+    def setup_environment(self, timeout=None):
+        fn_app_name = "fdk-python-unittest"
+        call_id = uuid.uuid4().hex
+        path = "/fdk-test"
+
+        os.environ.setdefault("FN_TYPE", "sync")
+        os.environ.setdefault("FN_FORMAT", self.fn_format)
+        os.environ.setdefault("FN_PATH", path)
+        os.environ.setdefault("FN_MEMORY", "256")
+        os.environ.setdefault("FN_APP_NAME", fn_app_name)
+        os.environ.setdefault("FN_REQUEST_URL",
+                              "https://fnservice.io/r/{0}{1}".format(
+                                  fn_app_name, path))
+        os.environ.setdefault("FN_CALL_ID", call_id)
+        os.environ.setdefault("FN_METHOD", "POST")
+        os.environ.setdefault("FN_DEADLINE", "")
+
+    def setup_protocol_frame(self, request_data, timeout=None):
+        fn_app_name = "fdk-python-unittest"
+        call_id = uuid.uuid4().hex
+        url = ("https://fnproject.io/r/{0}{1}".
+               format(fn_app_name, "/fdk-test"))
+        method = "POST"
+
+        now = dt.datetime.now(
+            dt.timezone.utc).astimezone()
+        extended = now + dt.timedelta(
+            seconds=timeout if timeout else 30)
+
+        if self.fn_format == "json":
+            json_request_with_body = {
+                "call_id": call_id,
+                "deadline": extended.isoformat(),
+                "body": request_data,
+                "content_type": "",
+                "protocol": {
+                    "type": "http",
+                    "method": method,
+                    "request_url": url,
+                    "headers": {
+                        "Accept": ["*/*", ],
+                        "User-Agent": ["curl/7.54.0"],
+                    }
+                }
+            }
+            return io.BytesIO(
+                ujson.dumps(
+                    json_request_with_body).encode("utf-8"))
+
+        if self.fn_format == "cloudevent":
+            cloudevent_request_with_body = {
+                "cloudEventsVersion": "0.1",
+                "eventID": uuid.uuid4().hex,
+                "source": "fdk-python-unittest",
+                "eventType": "cloudevent-fdk-python-unittest",
+                "eventTypeVersion": "0.1",
+                "eventTime": now.isoformat(),
+                "schemaURL": "...",
+                "contentType": "application/json",
+                "extensions": {
+                    "deadline": extended.isoformat(),
+                    "protocol": {
+                        "type": "http",
+                        "method": method,
+                        "request_url": url,
+                        "headers": {
+                            "Accept": ["*/*", ],
+                            "User-Agent": ["curl/7.54.0"],
+                        }
+                    }
+                },
+                "data": request_data
+            }
+            return io.BytesIO(
+                ujson.dumps(
+                    cloudevent_request_with_body).encode("utf-8"))
+
+        raise Exception("unknown format")
+
+    def assertInHeaders(self, key, value=None, message=None):
+        r = runner.handle_request(
+            self.__func, self.__protocol_frame, self.fn_format)
+        r = self.loop.run_until_complete(r)
+        self.assertIn(key, r.headers())
+
+        if value is not None:
+            header_value = r.headers().get(key)
+            self.assertEqual(value, header_value)
+
+    def assertInTime(self, timeout, message=None):
+        frame = self.setup_protocol_frame(
+            self.__func_data, timeout=timeout)
+        r = runner.handle_request(
+            self.__func, frame, self.fn_format)
+        r = self.loop.run_until_complete(r)
+
+        self.assertIsNotNone(r)
+        self.assertEqual(200, r.status(), message=message)
+
+    def assertNotInTime(self, timeout, message=None):
+        frame = self.setup_protocol_frame(
+            self.__func_data, timeout=timeout)
+        r = runner.handle_request(
+            self.__func, frame, self.fn_format)
+        r = self.loop.run_until_complete(r)
+
+        self.assertIsNotNone(r)
+        self.assertEqual(
+            502, r.status(),
+            message="function's response code must be 502, "
+                    "but was {0}".format(r.status()))
+        self.assertIn("function timed out",
+                      r.body()["error"]["message"])
+
+    def assertResponseConsistent(self, response_validator_func, message=None):
+        r = runner.handle_request(
+            self.__func, self.__protocol_frame, self.fn_format)
+        r = self.loop.run_until_complete(r)
+
+        ok = response_validator_func(r.body())
+        self.assertEqual(True, ok, message=message)

--- a/fdk/headers.py
+++ b/fdk/headers.py
@@ -28,6 +28,16 @@ class GoLikeHeaders(object):
         for k, v in headers.copy().items():
             self.set(k, v)
 
+    def __contains__(self, item: str):
+        """
+        Implements `if ... in ...` protocol on headers
+        :param item: header key
+        :type item: str
+        :return: true/false whether header key is headers
+        :rtype: bool
+        """
+        return item in self.__headers
+
     def get(self, key, default=None):
         """
         :param key:

--- a/fdk/tests/test_fixtures.py
+++ b/fdk/tests/test_fixtures.py
@@ -1,0 +1,63 @@
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from fdk import fixtures
+from fdk.tests import funcs
+
+
+class TestFuncToTest(fixtures.FunctionTestCase):
+
+    content = "OK"
+
+    def setUp(self):
+        super(TestFuncToTest, self).setUp(
+            self.content, funcs.content_type)
+
+    def tearDown(self):
+        super(TestFuncToTest, self).tearDown()
+
+    def test_response_data(self):
+        self.assertResponseConsistent(
+            lambda x: x == self.content,
+            message="content must be equal to '{0}'"
+            .format(self.content)
+        )
+
+    def test_response_header_presence(self):
+        self.assertInHeaders(
+            "content-type",
+            message="header 'content-type' "
+                    "must be present in headers")
+
+    def test_response_header_value(self):
+        self.assertInHeaders(
+            "content-type", value='application/xml',
+            message="header 'content-type' "
+                    "must be present in headers with the exact value")
+
+
+class TestFuncTimer(fixtures.FunctionTestCase):
+
+    def setUp(self):
+        super(TestFuncTimer, self).setUp(
+            None, funcs.timed_sleepr(6))
+
+    def tearDown(self):
+        super(TestFuncTimer, self).tearDown()
+
+    def test_not_in_time(self):
+        self.assertNotInTime(5)
+
+    def test_in_time(self):
+        self.assertInTime(8)

--- a/fdk/tests/test_headers.py
+++ b/fdk/tests/test_headers.py
@@ -29,6 +29,7 @@ class TestHeaders(testtools.TestCase):
 
         self.assertEqual(headers.for_dump(),
                          self.to_go_like_headers(header_dict))
+        self.assertIn("User-Agent", headers)
 
     def to_go_like_headers(self, headers):
         return {k: v if isinstance(v, (list, tuple)) else [v]

--- a/release.sh
+++ b/release.sh
@@ -5,3 +5,4 @@ git checkout -b v${FDK_VERSION}-stable
 git push origin v${FDK_VERSION}-stable
 PBR_VERSION=${FDK_VERSION} python setup.py sdist bdist_wheel
 twine upload dist/fdk-${FDK_VERSION}*
+git checkout master

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ ujson==1.35
 requests==2.18.4
 dill==0.2.7.1
 iso8601==0.1.12
+testtools>=1.4.0 # MIT


### PR DESCRIPTION
This PR adds an ability to write unittests for functions.

[Fn CLI](https://github.com/fnproject/cli) offers a very first compatibility barrier between your code and Fn server 
by allowing developers to perform black-box testing using the following CLI call with a function's folder:
```bash
fn test
```

This CLI call depends on `test.json` file that contains an input and the output data for the black-box testing.

Starting v0.0.33 FDK-Python will provide a testing framework that allows performing unit tests of your function's code.
The framework is an extension to [testtools](https://testtools.readthedocs.io/en/latest/) testing framework, coding style remain the same, so, write your tests as you've got used to.
Here's the example of the test suite:
```python
from fdk import fixtures
from fdk.tests import funcs


class TestFuncToTest(fixtures.FunctionTestCase):

    content = "OK"

    def setUp(self):
        super(TestFuncToTest, self).setUp(
            self.content, funcs.content_type)

    def tearDown(self):
        super(TestFuncToTest, self).tearDown()

    def test_response_data(self):
        self.assertResponseConsistent(
            lambda x: x == self.content,
            message="content must be equal to '{0}'"
            .format(self.content)
        )

    def test_response_header_presence(self):
        self.assertInHeaders(
            "content-type",
            message="header 'content-type' "
                    "must be present in headers")

    def test_response_header_value(self):
        self.assertInHeaders(
            "content-type", value='application/xml',
            message="header 'content-type' "
                    "must be present in headers with the exact value")

```

As you may see, the framework provides new assertion methods like:

 * assertInHeaders - allows to assert header(s) presence in response
 * assertInTime - allows asserting the time necessary for a function to finish
 * assertNotInTime - allows asserting the time within a function was not able to finish
 * assertResponseConsistent - allows asserting function's response content consistency by accepting a callable object that must return a boolean value that states the consistency


Closes: #17 