### PR TITLE
Fix setuptools classfier reference

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ classifier =
     Operating System :: POSIX :: Linux
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7.1
+    Programming Language :: Python :: 3.7
 
 [files]
 packages =


### PR DESCRIPTION
in order to build a wheel, there's a need to fix setup classifier
one-line change
twine uploader fails to push new release for Python 3.7.1 classifier.

