### PR TITLE
Adding Py3.5.2+ support

### DIFF
--- a/fdk/constants.py
+++ b/fdk/constants.py
@@ -12,6 +12,8 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import sys
+
 ASYNC_IO_READ_BUFFER = 65536
 DEFAULT_DEADLINE = 30
 HTTPSTREAM = "http-stream"
@@ -29,3 +31,9 @@ CONTENT_TYPE = "content-type"
 CONTENT_LENGTH = "Content-Length"
 FN_ENFORCED_RESPONSE_CODES = [200, 502, 504]
 FN_DEFAULT_RESPONSE_CODE = 200
+
+
+# todo: python 3.8 is on its way, make more flexible
+def is_py37():
+    py_version = sys.version_info
+    return (py_version.major, py_version.minor) == (3, 7)

--- a/fdk/tests/test_delayed_loader.py
+++ b/fdk/tests/test_delayed_loader.py
@@ -1,0 +1,53 @@
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import pytest
+
+from fdk import constants
+from fdk import customer_code
+
+from fdk.tests import funcs
+
+
+@pytest.mark.skipif(constants.is_py37(),
+                    reason="this test is for Python 3.5.2+ only")
+def test_py352plus():
+    dm = customer_code.Python35plusDelayedImport(funcs.__file__)
+    assert dm.executed is False
+
+    m = dm.get_module()
+    assert dm.executed is True
+    assert m is not None
+
+
+@pytest.mark.skipif(not constants.is_py37(),
+                    reason="this test is for Python 3.7.1+ only")
+def test_py37():
+    dm = customer_code.Python37DelayedImport(funcs.__file__)
+    assert dm.executed is False
+
+    m = dm.get_module()
+    assert dm.executed is True
+    assert m is not None
+
+
+def test_generic_delayed_loader():
+    f = customer_code.Function(
+        funcs.__file__, entrypoint="content_type")
+    assert f is not None
+    assert f._delayed_module_class.executed is False
+
+    h = f.handler()
+    assert h is not None
+    assert f._delayed_module_class.executed is True

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,12 @@
 [tox]
-envlist = py{3.7},pep8
+envlist = py{3.7,3.6},pep8
 skipsdist = True
 
 [testenv]
 basepython =
     pep8: python3.7
     py3.7: python3.7
+    py3.6: python3.6
 
 passenv =
         DOCKER_HOST
@@ -27,6 +28,9 @@ commands = {posargs}
 
 
 [testenv:py3.7]
+commands = pytest -v -s --tb=long --cov=fdk {toxinidir}/fdk/tests
+
+[testenv:py3.6]
 commands = pytest -v -s --tb=long --cov=fdk {toxinidir}/fdk/tests
 
 [flake8]


### PR DESCRIPTION
 In order to make FDL work with Python 3.5.2+ the following changes
 needed:

 - "start_serving" available from 3.7.1, so, I had to do some plumbing and version checks
 - importlib available also from 3.7.1, but it was available before but with different API,
   as for now, it is considered as deprecated in favour of "importlib"

Closes: #69 
