### PR TITLE
Make gen script add build/run images into func.yaml

### DIFF
--- a/generate_func.sh
+++ b/generate_func.sh
@@ -9,7 +9,12 @@ pip${PY_VERSION} install wheel
 
 python${PY_VERSION} setup.py bdist_wheel
 
+rm -fr test_function
 fn init --runtime python test_function || true
+
+echo "build_image: fnproject/python:${PY_VERSION}-dev" >> test_function/func.yaml
+echo "run_image: fnproject/python:${PY_VERSION}" >> test_function/func.yaml
+
 pip${PY_VERSION} download -r test_function/requirements.txt -d test_function/.pip_cache
 
 rm -fr test_function/.pip_cache/fdk*


### PR DESCRIPTION
This change adds some verbosity into code generation by explicitly specifying build/run images in the `func.yaml` with respect to host python runtime version.
