### PR TITLE
Add fn user/group to 3.6 runtime image

### DIFF
--- a/images/runtime/3.6/Dockerfile
+++ b/images/runtime/3.6/Dockerfile
@@ -1,1 +1,3 @@
 FROM python:3.6-slim-stretch
+
+RUN addgroup --gid 1000 --system fn && adduser --system --uid 1000 --ingroup fn fn


### PR DESCRIPTION
I somehow missed 3.6 runtime... added the fn user/group there too.