### PR TITLE
fix gateway headers / headers casing

### DIFF
--- a/fdk/constants.py
+++ b/fdk/constants.py
@@ -16,26 +16,32 @@ import sys
 
 ASYNC_IO_READ_BUFFER = 65536
 DEFAULT_DEADLINE = 30
+
 HTTPSTREAM = "http-stream"
 INTENT_HTTP_REQUEST = "httprequest"
+
+# env vars
 FN_FORMAT = "FN_FORMAT"
 FN_LISTENER = "FN_LISTENER"
-FN_INTENT = "Fn-Intent"
-FN_HTTP_PREFIX = "Fn-Http-H-"
-FN_HTTP_STATUS = "Fn-Http-Status"
+FN_APP_ID = "FN_APP_ID"
+FN_ID = "FN_FN_ID"
+FN_LOGFRAME_NAME = "FN_LOGFRAME_NAME"
+FN_LOGFRAME_HDR = "FN_LOGFRAME_HDR"
+
+# headers are lower case TODO(denis): why?
+FN_INTENT = "fn-intent"
+FN_HTTP_PREFIX = "fn-http-h-"
+FN_HTTP_STATUS = "fn-http-status"
 FN_DEADLINE = "fn-deadline"
-FN_FDK_VERSION = "Fn-Fdk-Version"
+FN_FDK_VERSION = "fn-fdk-version"
 FN_HTTP_REQUEST_URL = "fn-http-request-url"
 FN_CALL_ID = "fn-call-id"
 FN_HTTP_METHOD = "fn-http-method"
-FN_APP_ID = "FN_APP_ID"
-FN_ID = "FN_FN_ID"
-CONTENT_TYPE = "Content-Type"
-CONTENT_LENGTH = "Content-Length"
+CONTENT_TYPE = "content-type"
+CONTENT_LENGTH = "content-length"
+
 FN_ENFORCED_RESPONSE_CODES = [200, 502, 504]
 FN_DEFAULT_RESPONSE_CODE = 200
-FN_LOGFRAME_NAME = "FN_LOGFRAME_NAME"
-FN_LOGFRAME_HDR = "FN_LOGFRAME_HDR"
 
 
 # todo: python 3.8 is on its way, make more flexible

--- a/fdk/context.py
+++ b/fdk/context.py
@@ -18,6 +18,7 @@ import os
 
 from fdk import constants
 from fdk import headers as hs
+from fdk import log
 
 
 class InvokeContext(object):
@@ -63,6 +64,8 @@ class InvokeContext(object):
         self.__response_headers = {}
         self.__fn_format = fn_format
 
+        log.log("request headers. gateway: {0} {1}"
+                .format(self.__is_gateway(), headers))
         if self.__is_gateway():
             self.__headers = hs.decap_headers(self.__headers)
 
@@ -92,11 +95,12 @@ class InvokeContext(object):
         return self.__deadline
 
     def SetResponseHeaders(self, headers, status_code):
+        log.log("setting headers. gateway: {0}".format(self.__is_gateway()))
         if self.__is_gateway():
             headers = hs.encap_headers(headers, status=status_code)
 
         for k, v in headers.items():
-            self.__response_headers[k] = v
+            self.__response_headers[k.lower()] = v
 
     def GetResponseHeaders(self):
         return self.__response_headers

--- a/fdk/headers.py
+++ b/fdk/headers.py
@@ -19,6 +19,7 @@ def decap_headers(hdsr):
     ctx_headers = {}
     if hdsr is not None:
         for k, v in hdsr.items():
+            k = k.lower()
             if k.startswith(constants.FN_HTTP_PREFIX):
                 ctx_headers[k.lstrip(constants.FN_HTTP_PREFIX)] = v
             else:
@@ -30,6 +31,7 @@ def encap_headers(headers, status=None):
     new_headers = {}
     if headers is not None:
         for k, v in headers.items():
+            k = k.lower()
             if (k == constants.CONTENT_TYPE or
                     k == constants.FN_FDK_VERSION or
                     k.startswith(constants.FN_HTTP_PREFIX)):

--- a/fdk/runner.py
+++ b/fdk/runner.py
@@ -101,6 +101,6 @@ async def handle_request(handler_code, format_def, **kwargs):
             headers=headers, status_code=200)
 
     except (Exception, TimeoutError) as ex:
-        log.log("exception appeared")
+        log.log("exception appeared: {0}".format(ex))
         traceback.print_exc(file=sys.stderr)
-        return errors.DispatchException(ctx, 502, str(ex), ).response()
+        return errors.DispatchException(ctx, 502, str(ex)).response()

--- a/fdk/tests/funcs.py
+++ b/fdk/tests/funcs.py
@@ -92,7 +92,7 @@ async def coro(ctx, **kwargs):
 def valid_xml(ctx, **kwargs):
     return response.Response(
         ctx, response_data=xml, headers={
-            "Content-Type": "application/xml",
+            "content-type": "application/xml",
         }
     )
 
@@ -100,7 +100,7 @@ def valid_xml(ctx, **kwargs):
 def invalid_xml(ctx, **kwargs):
     return response.Response(
         ctx, response_data=json.dumps(xml), headers={
-            "Content-Type": "application/xml",
+            "content-type": "application/xml",
         }
     )
 

--- a/fdk/tests/test_http_stream.py
+++ b/fdk/tests/test_http_stream.py
@@ -32,7 +32,7 @@ async def test_override_content_type():
 
     assert 200 == status
     assert "OK" == content
-    assert "application/json" in headers.get("Content-Type")
+    assert "application/json" in headers.get("content-type")
     assert version.VERSION == headers.get(constants.FN_FDK_VERSION)
 
 
@@ -74,8 +74,8 @@ async def test_encap_headers_gw():
     call = await fixtures.setup_fn_call(
         funcs.encaped_header,
         headers={
-            "Custom-Header-Maybe": "yo",
-            "Content-Type": "application/yo"
+            "custom-header-maybe": "yo",
+            "content-type": "application/yo"
         },
         gateway=True,
     )
@@ -84,8 +84,8 @@ async def test_encap_headers_gw():
     # make sure that content type is not encaped, and custom header is
     # when coming out of the fdk
     assert 200 == status
-    assert "application/yo" in headers.get("Content-Type")
-    assert "yo" in headers.get("Fn-Http-H-Custom-Header-Maybe")
+    assert "application/yo" in headers.get("content-type")
+    assert "yo" in headers.get("fn-http-h-custom-header-maybe")
 
 
 @pytest.mark.asyncio
@@ -93,16 +93,16 @@ async def test_encap_headers():
     call = await fixtures.setup_fn_call(
         funcs.encaped_header,
         headers={
-            "Custom-Header-Maybe": "yo",
-            "Content-Type": "application/yo"
+            "custom-header-maybe": "yo",
+            "content-type": "application/yo"
         }
     )
     content, status, headers = await call
 
     # make sure that custom header is not encaped out of fdk
     assert 200 == status
-    assert "application/yo" in headers.get("Content-Type")
-    assert "yo" in headers.get("Custom-Header-Maybe")
+    assert "application/yo" in headers.get("content-type")
+    assert "yo" in headers.get("custom-header-maybe")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
the http library we're using automatically lower cases headers, and we weren't
properly handling different cases when encapsulating certain headers such as
content type and the gateway headers. this changes most of the headers to be
turned into lower case to check them and lower cases them going out of the
response in order to test them as well. over the wire itself, fn via the go
http library will end up turning these into the canonical header casing, but
for consistency in python this seems ideal. there are tests to ensure these
are checked properly in various cases now.

closes #87


