### PR TITLE
properly grab content type

### DIFF
--- a/fdk/async_http/app.py
+++ b/fdk/async_http/app.py
@@ -82,7 +82,7 @@ class AsyncHTTPServer(object):
             response = HTTPResponse(
                 body=body, status=status,
                 headers=headers,
-                content_type=headers.get("Content-Type")
+                content_type=headers.get(constants.CONTENT_TYPE, "text/plain")
             )
         except CancelledError:
             response = None

--- a/fdk/async_http/app.py
+++ b/fdk/async_http/app.py
@@ -80,9 +80,7 @@ class AsyncHTTPServer(object):
             headers = res.headers
             status = res.status
             response = HTTPResponse(
-                body=body, status=status,
-                headers=headers,
-                content_type=headers.get(constants.CONTENT_TYPE, "text/plain")
+                body=body, status=status, headers=headers,
             )
         except CancelledError:
             response = None

--- a/fdk/async_http/response.py
+++ b/fdk/async_http/response.py
@@ -131,6 +131,57 @@ class StreamingHTTPResponse(BaseHTTPResponse):
         )
 
 
+# CaseInsensitiveDict for headers. TODO should we let users use it in fdk too?
+class CaseInsensitiveDict(dict):
+    @classmethod
+    def _k(cls, key):
+        return key.lower() if isinstance(key, str) else key
+
+    def __init__(self, *args, **kwargs):
+        super(CaseInsensitiveDict, self).__init__(*args, **kwargs)
+        self._convert_keys()
+
+    def __getitem__(self, key):
+        return super(CaseInsensitiveDict, self).__getitem__(
+            self.__class__._k(key))
+
+    def __setitem__(self, key, value):
+        super(CaseInsensitiveDict, self).__setitem__(
+            self.__class__._k(key), value)
+
+    def __delitem__(self, key):
+        return super(CaseInsensitiveDict, self).__delitem__(
+            self.__class__._k(key))
+
+    def __contains__(self, key):
+        return super(CaseInsensitiveDict, self).__contains__(
+            self.__class__._k(key))
+
+    # DEPRECATED
+    # def has_key(self, key):
+
+    def pop(self, key, *args, **kwargs):
+        return super(CaseInsensitiveDict, self).pop(
+            self.__class__._k(key), *args, **kwargs)
+
+    def get(self, key, *args, **kwargs):
+        return super(CaseInsensitiveDict, self).get(
+            self.__class__._k(key), *args, **kwargs)
+
+    def setdefault(self, key, *args, **kwargs):
+        return super(CaseInsensitiveDict, self).setdefault(
+            self.__class__._k(key), *args, **kwargs)
+
+    def update(self, E={}, **F):
+        super(CaseInsensitiveDict, self).update(self.__class__(E))
+        super(CaseInsensitiveDict, self).update(self.__class__(**F))
+
+    def _convert_keys(self):
+        for k in list(self.keys()):
+            v = super(CaseInsensitiveDict, self).pop(k)
+            self.__setitem__(k, v)
+
+
 class HTTPResponse(BaseHTTPResponse):
     __slots__ = ("body", "status", "content_type", "headers", "_cookies")
 
@@ -150,7 +201,7 @@ class HTTPResponse(BaseHTTPResponse):
             self.body = body_bytes
 
         self.status = status
-        self.headers = dict(headers or {})
+        self.headers = CaseInsensitiveDict(headers or {})
         self._cookies = None
 
     def output(self, version="1.1", keep_alive=False, keep_alive_timeout=None):

--- a/fdk/runner.py
+++ b/fdk/runner.py
@@ -21,7 +21,6 @@ import iso8601
 import types
 
 from fdk import context
-from fdk import constants
 from fdk import customer_code
 from fdk import errors
 from fdk import log
@@ -91,11 +90,6 @@ async def handle_request(handler_code, format_def, **kwargs):
 
         headers = ctx.GetResponseHeaders()
         log.log("response headers obtained")
-        response_content_type = headers.get(
-            constants.CONTENT_TYPE, "text/plain"
-        )
-        headers[constants.CONTENT_TYPE] = response_content_type
-
         return response.Response(
             ctx, response_data=response_data,
             headers=headers, status_code=200)

--- a/fdk/tests/test_http_stream.py
+++ b/fdk/tests/test_http_stream.py
@@ -33,6 +33,9 @@ async def test_override_content_type():
     assert 200 == status
     assert "OK" == content
     assert "application/json" in headers.get("content-type")
+    # we've had issues with 'Content-Type: None' slipping in
+    assert len(headers.get("Content-Type")) == 0
+    assert len(headers.get("content-type")) == 1
     assert version.VERSION == headers.get(constants.FN_FDK_VERSION)
 
 

--- a/fdk/tests/test_http_stream.py
+++ b/fdk/tests/test_http_stream.py
@@ -32,10 +32,9 @@ async def test_override_content_type():
 
     assert 200 == status
     assert "OK" == content
-    assert "application/json" in headers.get("content-type")
+    assert headers.get("content-type") == "application/json"
     # we've had issues with 'Content-Type: None' slipping in
-    assert len(headers.get("Content-Type")) == 0
-    assert len(headers.get("content-type")) == 1
+    assert headers.get("Content-Type") is None
     assert version.VERSION == headers.get(constants.FN_FDK_VERSION)
 
 


### PR DESCRIPTION
add case insensitive dict to async_http lib

removes any higher level setting of the content type, since the async_http lib
itself will handle this and only at that level do we have case insensitive
header checks. it wasn't worth trying to change all of async_http header
getting to use lower case.