### PR TITLE
Fix request URL and HTTP method definitions

### DIFF
--- a/fdk/context.py
+++ b/fdk/context.py
@@ -106,10 +106,10 @@ class InvokeContext(object):
         return self.__response_headers
 
     def RequestURL(self):
-        return self.__invoke_context._request_url
+        return self._request_url
 
     def Method(self):
-        return self.__invoke_context._method
+        return self._method
 
     def __is_gateway(self):
         return (constants.FN_INTENT in self.__headers and

--- a/fdk/fixtures.py
+++ b/fdk/fixtures.py
@@ -53,12 +53,15 @@ def setup_headers(deadline=None, headers=None,
         new_headers = hs.encap_headers(headers)
         new_headers.update({
             constants.FN_INTENT: constants.INTENT_HTTP_REQUEST,
-            constants.FN_HTTP_REQUEST_URL: request_url,
-            constants.FN_HTTP_METHOD: method,
         })
     elif headers is not None:
         for k, v in headers.items():
             new_headers.update({k: v})
+
+    new_headers.update({
+        constants.FN_HTTP_REQUEST_URL: request_url,
+        constants.FN_HTTP_METHOD: method,
+    })
 
     if deadline is None:
         now = dt.datetime.now(dt.timezone.utc).astimezone()

--- a/fdk/tests/funcs.py
+++ b/fdk/tests/funcs.py
@@ -114,9 +114,8 @@ def verify_request_headers(ctx, **kwargs):
 
 
 def access_request_url(ctx, **kwargs):
-    hs = ctx.Headers()
     method = ctx.Method()
-    request_url = hs.get("Fn-Http-Request-Url")
+    request_url = ctx.RequestURL()
     return response.Response(
         ctx, response_data="OK", headers={
             "Response-Request-URL": request_url,

--- a/fdk/tests/test_http_stream.py
+++ b/fdk/tests/test_http_stream.py
@@ -193,3 +193,42 @@ def test_log_frame_header(monkeypatch, capsys):
     captured = capsys.readouterr()
     assert "\nfoo=12345\n" in captured.out
     assert "\nfoo=12345\n" in captured.err
+
+
+@pytest.mark.asyncio
+async def test_request_url_and_method_no_gateway():
+    url_path = "/call"
+    method = "POST"
+    call = await fixtures.setup_fn_call(
+        funcs.access_request_url,
+        request_url=url_path,
+        method=method,
+    )
+    content, status, headers = await call
+
+    assert "response-request-url" in headers
+    assert "request-method" in headers
+
+    assert url_path == headers.get("response-request-url")
+    assert method == headers.get("request-method")
+
+
+@pytest.mark.asyncio
+async def test_request_url_and_method_with_gateway():
+    url_path = "/t/app/path"
+    method = "GET"
+    call = await fixtures.setup_fn_call(
+        funcs.access_request_url,
+        request_url=url_path,
+        method=method,
+        gateway=True
+    )
+    content, status, headers = await call
+
+    assert "response-request-url" not in headers
+    assert "request-method" not in headers
+    assert "fn-http-h-response-request-url" in headers
+    assert "fn-http-h-request-method" in headers
+
+    assert url_path == headers.get("fn-http-h-response-request-url")
+    assert method == headers.get("fn-http-h-request-method")

--- a/fdk/version.py
+++ b/fdk/version.py
@@ -1,1 +1,1 @@
-VERSION = "0.1.7"
+VERSION = "0.1.8"


### PR DESCRIPTION
For some reason of the testing functions wasn't actually tested.

InvokeContext no longer has `__invoke_context` attributed due to recent changes to the context class itself.
This PR is making methods `RequestURL` and `Method` of the `InvokeContext` work again.

Closes: #94
