### PR TITLE
fix value of fn-fdk-version to include the fdk language

### DIFF
--- a/fdk/constants.py
+++ b/fdk/constants.py
@@ -46,6 +46,7 @@ FN_DEFAULT_RESPONSE_CODE = 200
 
 VERSION_HEADER_VALUE = "fdk-python/" + version.VERSION
 
+
 # todo: python 3.8 is on its way, make more flexible
 def is_py37():
     py_version = sys.version_info

--- a/fdk/constants.py
+++ b/fdk/constants.py
@@ -13,6 +13,7 @@
 #    under the License.
 
 import sys
+from fdk import version
 
 ASYNC_IO_READ_BUFFER = 65536
 DEFAULT_DEADLINE = 30
@@ -43,6 +44,7 @@ CONTENT_LENGTH = "content-length"
 FN_ENFORCED_RESPONSE_CODES = [200, 502, 504]
 FN_DEFAULT_RESPONSE_CODE = 200
 
+VERSION_HEADER_VALUE = "fdk-python/" + version.VERSION
 
 # todo: python 3.8 is on its way, make more flexible
 def is_py37():

--- a/fdk/response.py
+++ b/fdk/response.py
@@ -14,7 +14,6 @@
 
 from fdk import context
 from fdk import constants
-from fdk import version
 
 
 class Response(object):
@@ -39,7 +38,7 @@ class Response(object):
         self.response_data = response_data if response_data else ""
         if headers is None:
             headers = {}
-        headers.update({constants.FN_FDK_VERSION: version.VERSION})
+        headers.update({constants.FN_FDK_VERSION: constants.VERSION_HEADER_VALUE})
         ctx.SetResponseHeaders(headers, status_code)
         self.ctx = ctx
 

--- a/fdk/response.py
+++ b/fdk/response.py
@@ -38,7 +38,8 @@ class Response(object):
         self.response_data = response_data if response_data else ""
         if headers is None:
             headers = {}
-        headers.update({constants.FN_FDK_VERSION: constants.VERSION_HEADER_VALUE})
+        headers.update({constants.FN_FDK_VERSION:
+                        constants.VERSION_HEADER_VALUE})
         ctx.SetResponseHeaders(headers, status_code)
         self.ctx = ctx
 

--- a/fdk/tests/test_http_stream.py
+++ b/fdk/tests/test_http_stream.py
@@ -34,7 +34,8 @@ async def test_override_content_type():
     assert headers.get("content-type") == "application/json"
     # we've had issues with 'Content-Type: None' slipping in
     assert headers.get("Content-Type") is None
-    assert headers.get(constants.FN_FDK_VERSION) == constants.VERSION_HEADER_VALUE
+    assert headers.get(
+        constants.FN_FDK_VERSION) == constants.VERSION_HEADER_VALUE
 
 
 @pytest.mark.asyncio

--- a/fdk/tests/test_http_stream.py
+++ b/fdk/tests/test_http_stream.py
@@ -19,7 +19,6 @@ import pytest
 from fdk import constants
 from fdk import event_handler
 from fdk import fixtures
-from fdk import version
 
 from fdk.tests import funcs
 
@@ -35,7 +34,7 @@ async def test_override_content_type():
     assert headers.get("content-type") == "application/json"
     # we've had issues with 'Content-Type: None' slipping in
     assert headers.get("Content-Type") is None
-    assert version.VERSION == headers.get(constants.FN_FDK_VERSION)
+    assert headers.get(constants.FN_FDK_VERSION) == constants.VERSION_HEADER_VALUE
 
 
 @pytest.mark.asyncio

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,3 +2,4 @@ flake8<2.7.0,>=2.6.0
 hacking==1.1.0
 pytest==4.0.1
 pytest-cov==2.4.0
+attrs==19.1.0


### PR DESCRIPTION
The value of the Fn-Fdk-Version header does not include the fdk language as specified in the docs: https://github.com/fnproject/docs/pull/70/files
This PR fixes the value of the header to match the specification "fdk-python/x.y.z" in the docs and the initial issue https://github.com/fnproject/fn/issues/1302 

- Fix the format of Fn-Fdk-Version header value

