### PR TITLE
fix release script to push version tags in correct format

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,8 @@ jobs:
       - checkout
       - restore_cache:
           key: deps1-{{ .Branch }}-{{ checksum "requirements.txt" }}
+      - setup_remote_docker:
+          docker_layer_caching: true
       - run:
           command: |
             sudo pip install twine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
       - restore_cache:
           key: deps1-{{ .Branch }}-{{ checksum "requirements.txt" }}
       - setup_remote_docker:
-          docker_layer_caching: true
+          docker_layer_caching: false
       - run:
           command: |
             sudo pip install twine

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,8 +40,6 @@ jobs:
       - checkout
       - restore_cache:
           key: deps1-{{ .Branch }}-{{ checksum "requirements.txt" }}
-      - setup_remote_docker:
-          docker_layer_caching: false
       - run:
           command: |
             sudo pip install twine

--- a/release.sh
+++ b/release.sh
@@ -22,12 +22,11 @@ echo "New version: $new_version"
 
 echo "VERSION = '${new_version}'" > fdk/version.py
 
-tag="$new_version"
+tag="v$new_version"
 git add -u
-git commit -m "FDK Python: $new_version release [skip ci]"
-git tag -f -a $tag -m "version $new_version"
-git push
-git push origin $tag
+git commit -m "FDK Python: v$new_version release [skip ci]"
+git tag -f -a $tag -m "version v$new_version"
+git push --tags origin master
 
 PBR_VERSION=${new_version} python setup.py sdist bdist_wheel
 twine upload -u ${FN_PYPI_USER} -p ${FN_PYPI_PSWD} dist/fdk-${new_version}*


### PR DESCRIPTION
This fixes the tag format being pushed by the release script to match the current convention, i.e. tags are in the format vX.X.X
