### PR TITLE
Fix issue with header prefixes, remove ambiguous header processing

### DIFF
--- a/fdk/context.py
+++ b/fdk/context.py
@@ -57,6 +57,7 @@ class InvokeContext(object):
         self.__call_id = call_id
         self.__config = config if config else {}
         self.__headers = headers if headers else {}
+        self.__http_headers = {}
         self.__deadline = deadline
         self.__content_type = content_type
         self._request_url = request_url
@@ -66,8 +67,10 @@ class InvokeContext(object):
 
         log.log("request headers. gateway: {0} {1}"
                 .format(self.__is_gateway(), headers))
+
         if self.__is_gateway():
-            self.__headers = hs.decap_headers(self.__headers)
+            self.__headers = hs.decap_headers(headers, True)
+            self.__http_headers = hs.decap_headers(headers, False)
 
     def AppID(self):
         return self.__app_id
@@ -83,6 +86,9 @@ class InvokeContext(object):
 
     def Headers(self):
         return self.__headers
+
+    def HTTPHeaders(self):
+        return self.__http_headers
 
     def Format(self):
         return self.__fn_format

--- a/fdk/fixtures.py
+++ b/fdk/fixtures.py
@@ -24,7 +24,6 @@ async def process_response(fn_call_coro):
     response_data = resp.body()
     response_status = resp.status()
     response_headers = resp.context().GetResponseHeaders()
-    print(response_headers)
 
     return response_data, response_status, response_headers
 
@@ -83,10 +82,17 @@ async def setup_fn_call(
         method=method, request_url=request_url,
         gateway=gateway
     )
+    return await setup_fn_call_raw(handle_func, content, new_headers)
+
+
+async def setup_fn_call_raw(handle_func, content=None, headers=None):
+
+    if headers is None:
+        headers = {}
 
     # don't decap headers, so we can test them
     # (just like they come out of fdk)
     return process_response(runner.handle_request(
         code(handle_func), constants.HTTPSTREAM,
-        headers=new_headers, data=content,
+        headers=headers, data=content,
     ))

--- a/fdk/tests/funcs.py
+++ b/fdk/tests/funcs.py
@@ -17,7 +17,6 @@ import json
 
 from fdk import response
 
-
 xml = """<!DOCTYPE mensaje SYSTEM "record.dtd">
 <record>
     <player_birthday>1979-09-23</player_birthday>
@@ -78,7 +77,6 @@ def none_func(ctx, data=None):
 
 
 def timed_sleepr(timeout):
-
     def sleeper(ctx, data=None):
         time.sleep(timeout)
 
@@ -122,3 +120,24 @@ def access_request_url(ctx, **kwargs):
             "Request-Method": method,
         }
     )
+
+
+captured_context = None
+
+
+def setup_context_capture():
+    global captured_context
+    captured_context = None
+
+
+def get_captured_context():
+    global captured_context
+    my_context = captured_context
+    captured_context = None
+    return my_context
+
+
+def capture_request_ctx(ctx, **kwargs):
+    global captured_context
+    captured_context = ctx
+    return response.Response(ctx, response_data="OK")

--- a/fdk/tests/test_headers.py
+++ b/fdk/tests/test_headers.py
@@ -1,0 +1,109 @@
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from fdk import headers
+
+
+def test_push_header():
+    cases = [
+        ({}, "k", "v", {"k": "v"}),
+        ({}, "k", ["v1", "v2"], {"k": ["v1", "v2"]}),
+        ({"k": "v1"}, "k", "v2", {"k": ["v1", "v2"]}),
+        ({"k": ["v1"]}, "k", "v2", {"k": ["v1", "v2"]}),
+        ({"k": ["v1"]}, "k", ["v2"], {"k": ["v1", "v2"]}),
+        ({"k": []}, "k", [], {"k": []}),
+        ({"k": ["v1"]}, "k", [], {"k": ["v1"]}),
+        ({"k": []}, "k", ["v1"], {"k": ["v1"]}),
+        ({"k": "v1"}, "k", ["v2", "v3"], {"k": ["v1", "v2", "v3"]}),
+        ({"k1": "v1"}, "k2", "v2", {"k1": "v1", "k2": "v2"}),
+
+    ]
+
+    for case in cases:
+        initial = case[0]
+        working = initial.copy()
+        key = case[1]
+        value = case[2]
+        result = case[3]
+        headers.push_header(working, key, value)
+        assert working == result, "Adding  %s:%s to %s" \
+                                  % (key, value, initial)
+
+
+def test_encap_no_headers():
+    encap = headers.encap_headers({})
+    assert not encap, "headers should be empty"
+
+
+def test_encap_simple_headers():
+    encap = headers.encap_headers({
+        "Test-header": "foo",
+        "name-Conflict": "h1",
+        "name-conflict": "h2",
+        "nAme-conflict": ["h3", "h4"],
+        "fn-http-h-name-conflict": "h5",
+        "multi-header": ["bar", "baz"]
+    })
+    assert "fn-http-h-test-header" in encap
+    assert "fn-http-h-name-conflict" in encap
+    assert "fn-http-h-multi-header" in encap
+
+    assert encap["fn-http-h-test-header"] == "foo"
+    assert set(encap["fn-http-h-name-conflict"]) == {"h1", "h2",
+                                                     "h3", "h4", "h5"}
+    assert encap["fn-http-h-multi-header"] == ["bar", "baz"]
+
+
+def test_encap_status():
+    encap = headers.encap_headers({}, 202)
+    assert "fn-http-status" in encap
+    assert encap["fn-http-status"] == "202"
+
+
+def test_encap_status_override():
+    encap = headers.encap_headers({"fn-http-status": 412}, 202)
+    assert "fn-http-status" in encap
+    assert encap["fn-http-status"] == "202"
+
+
+def test_content_type_version():
+    encap = headers.encap_headers({"content-type": "text/plain",
+                                   "fn-fdk-version": "1.2.3"})
+
+    assert encap == {"content-type": "text/plain", "fn-fdk-version": "1.2.3"}
+
+
+def test_decap_headers_merge():
+    decap = headers.decap_headers({"fn-http-h-Foo-Header": "v1",
+                                   "fn-http-h-merge-header": "v2",
+                                   "fn-http-h-merge-Header": ["v3"],
+                                   "Foo-Header": "ignored",
+                                   "other-header": "bob"}, True)
+    assert "foo-header" in decap
+    assert decap["foo-header"] == "v1"
+
+    assert "other-header" in decap
+    assert decap["other-header"] == "bob"
+
+    assert "merge-header" in decap
+    assert set(decap["merge-header"]) == {"v2", "v3"}
+
+
+def test_decap_headers_strip():
+    decap = headers.decap_headers({"fn-http-h-Foo-Header": "v1",
+                                   "fn-http-h-merge-header": ["v2"],
+                                   "Foo-Header": "ignored",
+                                   "merge-header": "v3",
+                                   "other-header": "bad"}, False)
+    assert decap == {"foo-header": "v1", "merge-header": ["v2"]}


### PR DESCRIPTION
The python FDK has ambiguous and incorrect behaviour around header processing: 

* It incorrectly processes HTTP gateway headers, using lstrip instead of substring: this causes strange behaviour when an HTTP header starts with any strings matching [fnhtp-]+ and where that string is stripped instead of the actual http prefix "fn-http-h" (e.g. fn-http-h-good -> "good" but fn-http-h-hello -> "ello") 
* It incorrectly collapses HTTP headers into the function headers - this makes it impossible for a user to capture the exact HTTP headers sent to an API gateway as they are intermingled with the underlying function call headers
* It ambiguously processes headers when this collapsing happens - (based on dictionary order) - so if I have two headers from functions  "fn-http-h-myheader" "myheader"  it may present either depending on the order the keys are evaluated in the dictionary 

This fix resolves all three problems. 

For the second problem, to avoid breaking an backwards compatibility I've added a `ctx.HTTPHeaders()` method which only returns the incoming request headers. 

The testing behaviour was also ambiguous  as it relies on the internal code in the FDK that is under test so I added a raw testing call that does not apply the internal transformations to headers to the test fixture. 

Rather than using the function boundary to assert data I added a global capture to the fixture to retrieve the exact context presented to the function for testing. 
