### PR TITLE
Refresh the Python FDK dependencies to more recent versions.

### DIFF
--- a/fdk/customer_code.py
+++ b/fdk/customer_code.py
@@ -50,10 +50,11 @@ class Python35plusDelayedImport(PythonDelayedImportAbstraction):
 
     def get_module(self):
         if not self.executed:
-            import imp
+            from importlib.machinery import SourceFileLoader
             fname, ext = os.path.splitext(
                 os.path.basename(self._mod_path))
-            self._func_module = imp.load_source(fname, self._mod_path)
+            self._func_module = SourceFileLoader(fname, self._mod_path)\
+                .load_module()
             self.executed = True
 
         return self._func_module

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-pbr!=2.1.0,>=2.0.0 # Apache-2.0
+pbr==5.4.5
 iso8601==0.1.12
-pytest==4.0.1
-pytest-asyncio==0.9.0
-httptools>=0.0.10
+pytest==5.4.3
+pytest-asyncio==0.12.0
+httptools>=0.1.1

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,5 @@
 flake8<2.7.0,>=2.6.0
 hacking==1.1.0
-pytest==4.0.1
-pytest-cov==2.4.0
+pytest==5.4.3
+pytest-cov==2.9.0
 attrs==19.1.0


### PR DESCRIPTION
Updated the dependency versions as follows:
```
pbr==5.4.5
pytest==5.4.3
pytest-asyncio==0.12.0
httptools>=0.1.1
pytest-cov==2.9.0
```

The version upgrade caused deprecation of `imp` library and it is now replaced with `importlib`.

Built and tested successfully by running:
```
- python3 -m venv .venv && source .venv/bin/activate
- pip install tox
- tox
```

