### PR TITLE
Add Python 3.8.5 images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 jobs:
   "test":
     docker:
-      - image: circleci/python:3.7.0
+      - image: circleci/python:3.8.5
     working_directory: ~/fdk-python
     steps:
       - checkout
@@ -31,10 +31,10 @@ jobs:
       - run:
           command: |
             . venv/bin/activate
-            tox -epy3.7
+            tox -epy3.8
   "deploy":
     docker:
-      - image: circleci/python:3.7.0
+      - image: circleci/python:3.8.5
     working_directory: ~/fdk-python
     steps:
       - checkout
@@ -56,6 +56,7 @@ jobs:
 
               ./build-images.sh 3.6
               ./build-images.sh 3.7.1
+              ./build-images.sh 3.8.5
               ./release.sh
               ./release_images.sh
             fi
@@ -98,6 +99,25 @@ jobs:
           policy_bundle_file_path: .circleci/.anchore/policy_bundle.json
       - anchore/parse_reports
 
+  "python385_security_check":
+    executor: anchore/anchore_engine
+    working_directory: ~/fdk-python
+    steps:
+      - setup_remote_docker:
+          docker_layer_caching: false
+      - checkout
+      - run:
+          name: Python 3.8.5 build
+          command: |
+            apk add bash
+            ./build-images.sh 3.8.5
+      - anchore/analyze_local_image:
+          image_name: "fnproject/python:3.8.5-dev fnproject/python:3.8.5"
+          timeout: '500'
+          policy_failure: true
+          policy_bundle_file_path: .circleci/.anchore/policy_bundle.json
+      - anchore/parse_reports
+
 workflows:
   version: 2
   build:
@@ -118,3 +138,4 @@ workflows:
     jobs:
       - "python36_security_check"
       - "python371_security_check"
+      - "python385_security_check"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Function development kit for Python
-The python FDK lets you write functions in python 3.6/3.7 
+The python FDK lets you write functions in python 3.6/3.7/3.8
 
 ## Simplest possible function 
  
@@ -306,12 +306,12 @@ Then just do:
 
 First of all create a test function:
 ```bash
-fn init --runtime python3.7.1 test-function
+fn init --runtime python3.8.5 test-function
 ```
 
 Create a Dockerfile in a function's folder:
 ```dockerfile
-FROM fnproject/python:3.7.1-dev as build-stage
+FROM fnproject/python:3.8.5-dev as build-stage
 
 ADD . /function
 WORKDIR /function
@@ -320,7 +320,7 @@ RUN pip3 install --target /python/  --no-cache --no-cache-dir fdk-test-py3-none-
 
 RUN rm -fr ~/.cache/pip /tmp* requirements.txt func.yaml Dockerfile .venv
 
-FROM fnproject/python:3.7.1
+FROM fnproject/python:3.8.5
 
 COPY --from=build-stage /function /function
 COPY --from=build-stage /python /python
@@ -398,7 +398,7 @@ If you've been using json lib to turn an incoming data into a dictionary you nee
 ### Dockerfile
 If you've been using CLI to build function without modifying runtime in `func.yaml` to `docker` 
 instead of `python` then the only thing you need is to update the CLI to the latest version and 
-pin your Python runtime version to `python` or `python3.7.1`.
+pin your Python runtime version to `python`, `python3.7.1`, or `python3.8.5`.
 
 If you've been using custom multi-stage Dockerfile (derived from what Fn CLI generates) 
 the only thing that is necessary to change is an `ENTRYPOINT` from:

--- a/build-images.sh
+++ b/build-images.sh
@@ -2,7 +2,7 @@
 
 set -xe
 
-pyversion=${1:-"3.7.1"}
+pyversion=${1:-"3.8.5"}
 
 pushd images/build-stage/${pyversion} && docker build -t fnproject/python:${pyversion}-dev . && popd
 pushd images/runtime/${pyversion} && docker build -t fnproject/python:${pyversion} . && popd

--- a/fdk/__init__.py
+++ b/fdk/__init__.py
@@ -28,7 +28,7 @@ from fdk.async_http import router
 
 def start(handle_code: customer_code.Function,
           uds: str,
-          loop: asyncio.AbstractEventLoop=None):
+          loop: asyncio.AbstractEventLoop = None):
     """
     Unix domain socket HTTP server entry point
     :param handle_code: customer's code

--- a/fdk/async_http/response.py
+++ b/fdk/async_http/response.py
@@ -117,7 +117,7 @@ class StreamingHTTPResponse(BaseHTTPResponse):
 
         headers = self._parse_headers()
 
-        if self.status is 200:
+        if self.status == 200:
             status = b"OK"
         else:
             status = STATUS_CODES.get(self.status)
@@ -227,7 +227,7 @@ class HTTPResponse(BaseHTTPResponse):
 
         headers = self._parse_headers()
 
-        if self.status is 200:
+        if self.status == 200:
             status = b"OK"
         else:
             status = STATUS_CODES.get(self.status, b"UNKNOWN RESPONSE")

--- a/fdk/context.py
+++ b/fdk/context.py
@@ -118,9 +118,9 @@ class InvokeContext(object):
         return self._method
 
     def __is_gateway(self):
-        return (constants.FN_INTENT in self.__headers and
-                self.__headers.get(constants.FN_INTENT) ==
-                constants.INTENT_HTTP_REQUEST)
+        return (constants.FN_INTENT in self.__headers
+                and self.__headers.get(constants.FN_INTENT)
+                == constants.INTENT_HTTP_REQUEST)
 
 
 def context_from_format(format_def: str, **kwargs) -> (

--- a/fdk/headers.py
+++ b/fdk/headers.py
@@ -62,8 +62,8 @@ def encap_headers(headers, status=None):
             k = k.lower()
             if k.startswith(constants.FN_HTTP_PREFIX):  # by default merge
                 push_header(new_headers, k, v)
-            if (k == constants.CONTENT_TYPE or
-                    k == constants.FN_FDK_VERSION):  # but don't merge these
+            if (k == constants.CONTENT_TYPE
+                    or k == constants.FN_FDK_VERSION):  # but don't merge these
                 new_headers[k] = v
             else:
                 push_header(new_headers, constants.FN_HTTP_PREFIX + k, v)

--- a/fdk/response.py
+++ b/fdk/response.py
@@ -20,10 +20,10 @@ from typing import Union
 class Response(object):
 
     def __init__(self, ctx: context.InvokeContext,
-                 response_data: Union[str, bytes]=None,
-                 headers: dict=None,
-                 status_code: int=200,
-                 response_encoding: str="utf-8"):
+                 response_data: Union[str, bytes] = None,
+                 headers: dict = None,
+                 status_code: int = 200,
+                 response_encoding: str = "utf-8"):
         """
         Creates an FDK-readable response object
         :param ctx: invoke context

--- a/fdk/tests/tcp_debug.py
+++ b/fdk/tests/tcp_debug.py
@@ -23,7 +23,7 @@ from fdk.async_http import app
 from fdk.async_http import router
 
 
-def handle(handle_code: customer_code.Function, port: int=5000):
+def handle(handle_code: customer_code.Function, port: int = 5000):
     """
     FDK entry point
     :param handle_code: customer's code

--- a/images/README.md
+++ b/images/README.md
@@ -12,6 +12,11 @@ pushd build-stage/3.7.1; docker build -t fnproject/python:3.7.1-dev .; popd
 pushd runtime/3.7.1; docker build -t fnproject/python:3.7.1 .; popd
 ```
 
+```sh
+pushd build-stage/3.8.5; docker build -t fnproject/python:3.8.5-dev .; popd
+pushd runtime/3.8.5; docker build -t fnproject/python:3.8.5 .; popd
+```
+
 Then push:
 
 ```sh
@@ -22,4 +27,9 @@ docker push fnproject/python:3.6
 ```sh
 docker push fnproject/python:3.7.1-dev
 docker push fnproject/python:3.7.1
+```
+
+```sh
+docker push fnproject/python:3.8.5-dev
+docker push fnproject/python:3.8.5
 ```

--- a/images/build-stage/3.8.5/Dockerfile
+++ b/images/build-stage/3.8.5/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.8.5-slim-buster
+
+RUN apt-get update && apt-get upgrade -qy && \
+    apt-get install --no-install-recommends -qy build-essential gcc && \
+    apt-get clean

--- a/images/runtime/3.8.5/Dockerfile
+++ b/images/runtime/3.8.5/Dockerfile
@@ -1,0 +1,4 @@
+FROM python:3.8.5-slim-buster
+
+RUN apt-get update && apt-get upgrade -qy && apt-get clean
+RUN addgroup --system --gid 1000 fn && adduser --system --uid 1000 --ingroup fn fn

--- a/release_images.sh
+++ b/release_images.sh
@@ -2,11 +2,15 @@
 
 user="fnproject"
 image="python"
-runtime36="3.6"
-runtime371="3.7.1"
 
+runtime36="3.6"
 docker push ${user}/${image}:${runtime36}
 docker push ${user}/${image}:${runtime36}-dev
 
+runtime371="3.7.1"
 docker push ${user}/${image}:${runtime371}
 docker push ${user}/${image}:${runtime371}-dev
+
+runtime385="3.8.5"
+docker push ${user}/${image}:${runtime385}
+docker push ${user}/${image}:${runtime385}-dev

--- a/samples/echo/func.py
+++ b/samples/echo/func.py
@@ -20,7 +20,7 @@ from fdk import fixtures
 from fdk import response
 
 
-def handler(ctx, data: io.BytesIO=None):
+def handler(ctx, data: io.BytesIO = None):
     name = "World"
     try:
         body = json.loads(data.getvalue())

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ classifier =
     Operating System :: POSIX :: Linux
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
 
 [files]
 packages =

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-flake8<2.7.0,>=2.6.0
+flake8>=2.6.0
 hacking==1.1.0
 pytest==5.4.3
 pytest-cov==2.9.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,11 @@
 [tox]
-envlist = py{3.7,3.6},pep8
+envlist = py{3.8,3.7,3.6},pep8
 skipsdist = True
 
 [testenv]
 basepython =
-    pep8: python3.7
+    pep8: python3.8
+    py3.8: python3.8
     py3.7: python3.7
     py3.6: python3.6
 
@@ -26,6 +27,8 @@ commands = flake8
 [testenv:venv]
 commands = {posargs}
 
+[testenv:py3.8]
+commands = pytest -v -s --tb=long --cov=fdk {toxinidir}/fdk/tests
 
 [testenv:py3.7]
 commands = pytest -v -s --tb=long --cov=fdk {toxinidir}/fdk/tests


### PR DESCRIPTION
Python 3.8.5 based off slim-buster is about 82% the size of slim-stretch.

- Link to issue this resolves: n/a

- What I did: added Python 3.8.5 (based off python:3.8.5-slim-buster)

- How I did it: looked for references to 3.7.1 and did the equivalent dance for 3.8.5

- How to verify it: use `FROM fnproject/python:3.7.1-dev [...]` in Dockerfile

- One line description for the changelog: Add Python 3.8.5 images

- One moving picture involving robots (not mandatory but encouraged): ![Trurl (thinking about the letter N)](https://raw.githubusercontent.com/dbushenko/trurl/master/img/trurl.jpg)
