### PR TITLE
Fix "None-None" race condition with keep-alive timeout

### DIFF
--- a/fdk/async_http/signpost.md
+++ b/fdk/async_http/signpost.md
@@ -1,0 +1,6 @@
+This code is from https://github.com/huge-success/sanic/
+
+It's modified and stripped-down because importing full sanic
+increased cold starts.
+
+See https://github.com/fnproject/fdk-python/pull/60 for context.

--- a/fdk/tests/test_protocol.py
+++ b/fdk/tests/test_protocol.py
@@ -1,0 +1,41 @@
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from fdk.async_http import protocol
+
+
+def http_protocol(**kwargs):
+    return protocol.HttpProtocol(
+        loop=None, request_handler=None, error_handler=None,
+        **kwargs)
+
+
+def test_keep_alive_time_left_before_time_is_set():
+    p = http_protocol()
+
+    protocol.current_time = None
+    p._last_request_time = None
+
+    time_left = p.keep_alive_time_left()
+    assert 0 == time_left
+
+
+def test_keep_alive_time_left_after_time_is_set():
+    p = http_protocol(keep_alive_timeout=15)
+
+    protocol.current_time = 96
+    p._last_response_time = 64
+
+    time_left = p.keep_alive_time_left()
+    assert 15 - 32 == time_left


### PR DESCRIPTION
Keep-alives are handled by a scheduled routine, which closes the
connection if the keep-alive has expired. The routine calculates the
keep-alive time remaining based on the last response time, but that's
not set until after the routine is scheduled, creating a race
condition. The fix is to set the last response time before scheduling
the keep-alive routine. Additionally the calculation is a bit more
robust now, so the scheduled routine doesn't need to deal with None.

- Addresses issue #103

- What I did: addressed a race condition

- How I did it: set a variable which is used inside a scheduled routine (`_last_response_time` used inside `keep_alive_timeout_callback()`) before the routine is scheduled

- How to verify it: added a test

- One line description for the changelog: Fix "None-None" race condition with keep-alive timeout

- One moving picture involving robots (not mandatory but encouraged): ![bebot](http://www.normalware.com/robot.png)
