### PR TITLE
Python logging enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,12 @@ You can set outbound HTTP headers and the HTTP status of the request using `ctx.
   - e.g. `ctx.SetResponseHeaders({"Location","http://example.com/","My-Header2": ["v1","v2"]}, 302)` 
   - or by passing these to the Response object : 
 ```python
-        return new Response(ctx,
-                        headers={"Location","http://example.com/","My-Header2": ["v1","v2"]},
-                        response_data="Page moved",
-                        status_code=302)
-``` 
+return new Response(
+    ctx,
+    headers={"Location","http://example.com/","My-Header2": ["v1","v2"]},
+    response_data="Page moved",
+    status_code=302)
+```
 
 e.g. to redirect users to a different page : 
 ```python
@@ -171,11 +172,11 @@ PASSED
 
 To add coverage first install one more package:
 ```bash
-    pip install pytest-cov
+pip install pytest-cov
 ```
 then run tests with coverage flag:
 ```bash
-    pytest -v -s --tb=long --cov=func func.py
+pytest -v -s --tb=long --cov=func func.py
 ```
 
 ```bash
@@ -208,15 +209,15 @@ func.py      19      1    95%
 
 Create a virtualenv:
 ```bash
-    python3 -m venv .venv
+python3 -m venv .venv
 ```
 Activate virtualenv:
 ```bash
-    source .venv/bin/activate
+source .venv/bin/activate
 ```
 All you have to do is:
 ```bash
-    pip install fdk
+pip install fdk
 ```
 Now you have a new tools added!
 
@@ -236,7 +237,7 @@ This is an entry point to a function, this tool you'd be using while working wit
 `fdk` is a Python CLI script that has the following signature:
 
 ```bash
-    fdk <path-to-a-function-module> [module-entrypoint]
+fdk <path-to-a-function-module> [module-entrypoint]
 ```
 
 where:
@@ -254,6 +255,20 @@ fdk func.py
 the CLI will look for `handler` Python function.
 In order to override `[module-entrypoint]` you need to specify your custom entry point.
 
+### Testing locally
+
+To run a function locally (outside Docker) you need to set `FN_FORMAT` and `FN_LISTENER`, like so:
+
+```bash
+env FDK_DEBUG=1 FN_FORMAT=http-stream FN_LISTENER=unix://tmp/func.sock fdk <path-to-a-function-module> [module-entrypoint]
+```
+
+You can then test with curl:
+
+```bash
+curl -v --unix-socket /tmp/func.sock -H "Fn-Call-Id: 0000000000000000" -H "Fn-Deadline: 2030-01-01T00:00:00.000Z" -XPOST http://function/call -d '{"name":"Tubbs"}'
+```
+
 ## CLI tool: `fdk-tcp-debug`
 
 The reason why this tool exists is to give a chance to developers to debug their function on their machines.
@@ -265,7 +280,7 @@ when this tool works on top of TCP socket, so, the difference is a transport, no
 `fdk-tcp-debug` is a Python CLI script that has the following signature:
 
 ```bash
-    fdk-tcp-debug <port> <path-to-a-function-module> [module-entrypoint]
+fdk-tcp-debug <port> <path-to-a-function-module> [module-entrypoint]
 ```
 
 The behaviour of this CLI is the same, but it will start an FDK on top of the TCP socket.
@@ -292,14 +307,14 @@ In order to test an FDK changes do the following:
 Test an FDK change with sample function using `fdk-tcp-debug`:
 
 ```bash
-    pip install -e .
-    FDK_DEBUG=1 fdk-tcp-debug 5001 samples/echo/func.py handler
+pip install -e .
+FDK_DEBUG=1 fdk-tcp-debug 5001 samples/echo/func.py handler
 ```
 
 Then just do:
 
 ```bash
-    curl -v -X POST localhost:5001 -d '{"name":"denis"}'
+curl -v -X POST localhost:5001 -d '{"name":"denis"}'
 ```
 
 ### Testing within a function
@@ -331,16 +346,16 @@ ENTRYPOINT ["/python/bin/fdk", "/function/func.py", "handler"]
 
 Build an FDK wheel:
 ```bash
-    pip install wheel
-    PBR_VERSION=test python setup.py bdist_wheel
+pip install wheel
+PBR_VERSION=test python setup.py bdist_wheel
 ```
 
 Move an FDK wheel (located at `dist/fdk-test-py3-none-any.whl`) into a function's folder.
 
 Do the deploy:
 ```bash
-    fn --versbose deploy --app testapp --local --no-bump
-    fn config fn testapp test-function FDK_DEBUG 1
+fn --versbose deploy --app testapp --local --no-bump
+fn config fn testapp test-function FDK_DEBUG 1
 ```
 
 And the last step - invoke it and see how it goes:
@@ -354,7 +369,7 @@ FDK is based on the asyncio event loop. Default event loop is not quite fast, bu
 In order to make an FDK to process IO operation at least 4 times faster you need to add another dependency to your function:
 
 ```text
-    uvloop
+uvloop
 ```
 
 [UVLoop](https://github.com/MagicStack/uvloop) is a CPython wrapper on top of cross-platform [libuv](https://github.com/libuv/libuv).
@@ -372,8 +387,8 @@ A new FDK is here which means there suppose to be a way to upgrade your code fro
 As you noticed - an entry point a function changed, i.e., func.py no longer considered as the main module (`__main__`) which means that the following section:
 
 ```python
-    if __name__ == "__main__":
-        fdk.handle(handler)
+if __name__ == "__main__":
+    fdk.handle(handler)
 ```
 
 has no effect any longer. Please note that FDK will fail-fast with an appropriate message if old-style FDK format used.
@@ -389,10 +404,10 @@ data = data.read()
 If you've been using json lib to turn an incoming data into a dictionary you need to replace: `json.loads` with `json.load`
 
 ```python
-    try:
-        dct = json.load(data)
-    except ValueError as ex:
-        # do here whatever is reasonable
+try:
+    dct = json.load(data)
+except ValueError as ex:
+    # do here whatever is reasonable
 ```
 
 ### Dockerfile
@@ -404,13 +419,13 @@ If you've been using custom multi-stage Dockerfile (derived from what Fn CLI gen
 the only thing that is necessary to change is an `ENTRYPOINT` from:
 
 ```text
-    ENTRYPOINT["python", "func.py"]
+ENTRYPOINT["python", "func.py"]
 ```
 
 to:
 
 ```text
-    ENTRYPOINT["/python/bin/fdk", "func.py", "handler"]
+ENTRYPOINT["/python/bin/fdk", "func.py", "handler"]
 ```
 
 If you've been using your own Dockerfile that wasn't derived from the Dockerfile 

--- a/fdk/async_http/app.py
+++ b/fdk/async_http/app.py
@@ -74,7 +74,7 @@ class AsyncHTTPServer(object):
 
             request.uri_template = uri
             response = handler(request)
-            logger.info("got response from function")
+            logger.debug("got response from function")
             res = await response
             body = res.body
             headers = res.headers

--- a/fdk/async_http/protocol.py
+++ b/fdk/async_http/protocol.py
@@ -251,7 +251,7 @@ class HttpProtocol(asyncio.Protocol):
                 time_left, self.keep_alive_timeout_callback
             )
         else:
-            logger.info("KeepAlive Timeout. Closing connection.")
+            logger.debug("KeepAlive Timeout. Closing connection.")
             self.transport.close()
             self.transport = None
 

--- a/fdk/async_http/server.py
+++ b/fdk/async_http/server.py
@@ -203,7 +203,7 @@ def serve(
     def start():
         pid = os.getpid()
         try:
-            logger.info("Starting worker [%s]", pid)
+            logger.debug("Starting worker [%s]", pid)
             if constants.is_py37():
                 loop.run_until_complete(http_server.serve_forever())
             else:

--- a/fdk/event_handler.py
+++ b/fdk/event_handler.py
@@ -18,6 +18,7 @@ import os
 import sys
 
 from fdk import constants
+from fdk import log
 
 from fdk.async_http import response
 
@@ -36,13 +37,13 @@ def event_handle(handle_code):
     """
     async def pure_handler(request):
         from fdk import runner
-        logger.info("in pure_handler")
+        log.log("in pure_handler")
         headers = dict(request.headers)
         log_frame_header(headers)
         func_response = await runner.handle_request(
             handle_code, constants.HTTPSTREAM,
             headers=headers, data=io.BytesIO(request.body))
-        logger.info("request execution completed")
+        log.log("request execution completed")
 
         headers = func_response.context().GetResponseHeaders()
         status = func_response.status()

--- a/fdk/log.py
+++ b/fdk/log.py
@@ -18,9 +18,14 @@ import sys
 
 
 def __setup_logger():
-    logging.getLogger("asyncio").setLevel(logging.DEBUG)
+    fdk_debug = os.environ.get("FDK_DEBUG") in [
+        'true', '1', 't', 'y', 'yes', 'yeah', 'yup', 'certainly', 'uh-huh']
+
+    logging.getLogger("asyncio").setLevel(logging.WARNING)
     root = logging.getLogger()
-    root.setLevel(logging.DEBUG)
+    if fdk_debug:
+        root.setLevel(logging.DEBUG)
+
     ch = logging.StreamHandler(sys.stderr)
     formatter = logging.Formatter(
         '%(asctime)s - '
@@ -30,7 +35,8 @@ def __setup_logger():
     )
     ch.setFormatter(formatter)
     root.addHandler(ch)
-    return root
+    logger = logging.getLogger("fdk")
+    return logger
 
 
 __log__ = __setup_logger()
@@ -41,7 +47,4 @@ def get_logger():
 
 
 def log(message):
-    fdk_debug = os.environ.get("FDK_DEBUG")
-    if fdk_debug in ['true', '1', 't', 'y', 'yes',
-                     'yeah', 'yup', 'certainly', 'uh-huh']:
-        __log__.info(message)
+    __log__.debug(message)

--- a/fdk/log.py
+++ b/fdk/log.py
@@ -37,8 +37,7 @@ def __setup_logger():
 
     logging.getLogger("asyncio").setLevel(logging.WARNING)
     root = logging.getLogger()
-    if fdk_debug:
-        root.setLevel(logging.DEBUG)
+    root.setLevel(logging.DEBUG)
 
     ch = logging.StreamHandler(sys.stderr)
     formatter = RequestFormatter(
@@ -50,6 +49,11 @@ def __setup_logger():
     ch.setFormatter(formatter)
     root.addHandler(ch)
     logger = logging.getLogger("fdk")
+    if fdk_debug:
+        logger.setLevel(logging.DEBUG)
+    else:
+        logger.setLevel(logging.WARNING)
+
     return logger
 
 


### PR DESCRIPTION
- Link to issue this resolves

n/a

- What I did

Python exception backtraces were sent as multiple separate lines. This
is inconvenient for logging services like Papertrail and OCI Logging
which create a record for each line. This patch formats the backtrace
as a single line.

The Call ID is logged with all log lines. This makes it easier to
identify which log lines belong to which call.

The current time is no longer logged.  Log destinations such as
Papertrail and OCI Logging record and display the log event time, so
this information is redundant.

Log to debug by default, but all FDK logging can still be seen by setting FDK_LOGGING=1.

- How I did it

Changed the formatter for the root logger to include `fn_request_id`, which is a context variable set by `runner.handle_request` before calling the user's code.

Changed other fdk logging from `info` to `debug` and only set FDK logging to `DEBUG` if FDK_DEBUG is defined.

- How to verify it

Start the fdk

```bash
% env FDK_DEBUG=1 FN_FORMAT=http-stream FN_LISTENER=unix://tmp/funk.sock fdk samples/echo/func.py
None - fdk - DEBUG - entering handle
None - fdk - DEBUG - FN_FORMAT is set, value: http-stream
None - fdk - DEBUG - FN_LISTENER is set, value: unix://tmp/funk.sock
None - fdk - DEBUG - in http_stream.start
None - fdk - DEBUG - deleting socket files if they exist
None - fdk - DEBUG - CHMOD 666 //tmp/phonyfunk.sock
None - fdk - DEBUG - phony socket permissions: 0o140666
None - fdk - DEBUG - calling '.start_serving()'
None - fdk - DEBUG - sym-linking //tmp/funk.sock to //tmp/phonyfunk.sock
None - fdk - DEBUG - socket permissions: 0o140666
None - fdk - DEBUG - starting infinite loop
None - fdk.async_http.server - DEBUG - Starting worker [55911]
```

Invoke from another terminal
```bash
% curl -v --unix-socket /tmp/funk.sock -H "Fn-Call-Id: SPECIALSTUFF" -H "Fn-Deadline: 2030-01-01T00:00:00.000Z" -XPOST -d"{}" http://function/call
```

See logs now include the call id
```text
None - fdk.async_http.app - DEBUG - got response from function
None - fdk - DEBUG - in pure_handler
None - fdk - DEBUG - in handle_request
None - fdk - DEBUG - request headers. gateway: False {'host': 'function', 'user-agent': 'curl/7.64.1', 'accept': '*/*', 'fn-call-id': 'SPECIALSTUFF', 'fn-deadline': '2030-01-01T00:00:00.000Z', 'content-length': '2', 'content-type': 'application/x-www-form-urlencoded'}
SPECIALSTUFF - fdk - DEBUG - context provisioned
SPECIALSTUFF - fdk - DEBUG - setting headers. gateway: False
SPECIALSTUFF - fdk - DEBUG - function result obtained
SPECIALSTUFF - fdk - DEBUG - request execution completed
```

or if an exception is thrown
```text
CREMEBRULEE - fn - ERROR - Hello, hello? What's going on? What's all this shouting? We'll have no trouble here!:  File "/Users/mrcurtis/p/fn/all/fdk-python/fdk/runner.py", line 87, in handle_request\n    response_data = await with_deadline(ctx, handler_code, body)\n  File "/Users/mrcurtis/p/fn/all/fdk-python/fdk/runner.py", line 67, in with_deadline\n    raise ex\n  File "/Users/mrcurtis/p/fn/all/fdk-python/fdk/runner.py", line 58, in with_deadline\n    result = handle_func(ctx, data=data)\n  File "func.py", line 23, in handler\n    raise ValueError("Hello, hello? What's going on? What's all this shouting? We'll have no trouble here!")\n
```

- One line description for the changelog

Python logging enhancements

- One moving picture involving robots (not mandatory but encouraged)

```
(0)_________________
/ \
```

(It's a Portal turret. It hasn't seen you.)