### PR TITLE
Fix dependency issue with python 3.6.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ iso8601==0.1.12
 pytest==5.4.3
 pytest-asyncio==0.12.0
 httptools>=0.1.1
+contextvars==2.4;python_version<"3.7"


### PR DESCRIPTION
A recent change introduce the use of the ContextVar package. That
package is included from python 3.7.0 but not in older versions. This
change adds that explicit dependency in case the version of python used
is less than 3.7.0

