### PR TITLE
Python timeout 504 status

### DIFF
--- a/fdk/tests/test_http_stream.py
+++ b/fdk/tests/test_http_stream.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 
-import datetime as dt
 import json
 import pytest
 

--- a/fdk/tests/test_http_stream.py
+++ b/fdk/tests/test_http_stream.py
@@ -135,20 +135,6 @@ async def test_coro_func():
 
 
 @pytest.mark.asyncio
-async def test_deadline():
-    timeout = 5
-    now = dt.datetime.now(dt.timezone.utc).astimezone()
-    now += dt.timedelta(0, float(timeout))
-
-    call = await fixtures.setup_fn_call(
-        funcs.timed_sleepr(timeout + 1),
-        deadline=now.isoformat())
-    _, status, _ = await call
-
-    assert 502 == status
-
-
-@pytest.mark.asyncio
 async def test_default_enforced_response_code():
     event_coro = event_handler.event_handle(
         fixtures.code(funcs.code404))


### PR DESCRIPTION

The python code was explicitly handling timeout using the **signal** library and was throwing 502 status code instead of 504(as per our [documentation](https://docs.oracle.com/en-us/iaas/Content/Functions/Tasks/functionstroubleshooting.htm)). Upon checking other FDKs we found that timeouts are not handled in the FDK rather it is the layer above it i.e. runners which handle the timeouts and it is responsible to kill the containers and return 504 status to the user. 

I removed the timeout handling code in Python and also measured the performance before and after code removal. Below are my findings. We don't see any degradation in performance post timeout code removal
 
<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:////Users/ronshaw/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip.htm">
<link rel=File-List
href="file:////Users/ronshaw/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip_filelist.xml">
<style>
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:12.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:Calibri, sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl63
	{color:black;
	font-size:11.0pt;
	font-family:Menlo, sans-serif;
	mso-font-charset:0;}
.xl64
	{border-top:none;
	border-right:none;
	border-bottom:none;
	border-left:1.0pt solid windowtext;}
.xl65
	{color:black;
	font-size:11.0pt;
	font-family:Menlo, sans-serif;
	mso-font-charset:0;
	border-top:none;
	border-right:1.0pt solid windowtext;
	border-bottom:none;
	border-left:none;}
.xl66
	{border-top:none;
	border-right:1.0pt solid windowtext;
	border-bottom:none;
	border-left:none;}
.xl67
	{border-top:none;
	border-right:none;
	border-bottom:1.0pt solid windowtext;
	border-left:1.0pt solid windowtext;}
.xl68
	{border-top:none;
	border-right:none;
	border-bottom:1.0pt solid windowtext;
	border-left:none;}
.xl69
	{color:black;
	font-size:11.0pt;
	font-family:Menlo, sans-serif;
	mso-font-charset:0;
	border-top:none;
	border-right:none;
	border-bottom:1.0pt solid windowtext;
	border-left:none;}
.xl70
	{color:black;
	font-size:11.0pt;
	font-family:Menlo, sans-serif;
	mso-font-charset:0;
	border-top:none;
	border-right:1.0pt solid windowtext;
	border-bottom:1.0pt solid windowtext;
	border-left:none;}
.xl71
	{font-size:20.0pt;
	font-weight:700;
	border-top:1.0pt solid windowtext;
	border-right:none;
	border-bottom:1.0pt solid windowtext;
	border-left:1.0pt solid windowtext;
	background:#FCE4D6;
	mso-pattern:black none;}
.xl72
	{font-size:20.0pt;
	font-weight:700;
	border-top:1.0pt solid windowtext;
	border-right:none;
	border-bottom:1.0pt solid windowtext;
	border-left:none;
	background:#FCE4D6;
	mso-pattern:black none;}
.xl73
	{font-size:20.0pt;
	font-weight:700;
	border-top:1.0pt solid windowtext;
	border-right:1.0pt solid windowtext;
	border-bottom:1.0pt solid windowtext;
	border-left:none;
	background:#FCE4D6;
	mso-pattern:black none;}
-->
</style>
</head>

<body link="#0563C1" vlink="#954F72">



Time out | Sleep Time | Mode | 1st run | 2nd run | 3rd run
-- | -- | -- | -- | -- | --
30 | 10 | With signal code | 0.21s user 0.09s system 1% cpu 16.872 total | 0.21s user 0.08s system 2% cpu 13.869 total | 0.20s user 0.07s system 2% cpu 13.661 total
30 | 50 | With signal code | 0.19s user 0.08s system 0% cpu 35.799 total | 0.22s user 0.09s system 0% cpu 32.654 total | 0.21s user 0.08s system 0% cpu 33.037 total
30 | NA | With signal code | 0.19s user 0.08s system 3% cpu 6.929 total | 0.19s user 0.08s system 7% cpu 3.799 total | 0.21s user 0.09s system 8% cpu 3.519 total
  |   |   |   |   |  
30 | 10 | Without signal code | 0.22s user 0.08s system 1% cpu 16.524 total | 0.21s user 0.09s system 2% cpu 13.918 total | 0.21s user 0.08s system 2% cpu 13.688 total
30 | 50 | Without signal code | 0.21s user 0.08s system 0% cpu 36.762 total | 0.21s user 0.09s system 0% cpu 35.518 total | 0.21s user 0.09s system 0% cpu 35.953 total
30 | NA | Without signal code | 0.19s user 0.08s system 3% cpu 7.169 total | 0.20s user 0.08s system 7% cpu 3.518 total | 0.20s user 0.09s system 6% cpu 4.138 total



</body>

</html>
