### PR TITLE
fix: stop clobbering root logger

### DIFF
--- a/fdk/log.py
+++ b/fdk/log.py
@@ -38,20 +38,11 @@ def __setup_logger():
         'true', '1', 't', 'y', 'yes', 'yeah', 'yup', 'certainly', 'uh-huh']
 
     logging.getLogger("asyncio").setLevel(logging.WARNING)
+    
     root = logging.getLogger()
-    root.setLevel(logging.DEBUG)
-
-    ch = logging.StreamHandler(sys.stderr)
-    formatter = RequestFormatter(
-        '%(fn_request_id)s - '
-        '%(name)s - '
-        '%(levelname)s - '
-        '%(message)s'
-    )
-    ch.setFormatter(formatter)
-    root.addHandler(ch)
     logger = logging.getLogger("fdk")
     if fdk_debug:
+        root.setLevel(logging.DEBUG)
         logger.setLevel(logging.DEBUG)
     else:
         logger.setLevel(logging.WARNING)

--- a/fdk/log.py
+++ b/fdk/log.py
@@ -41,6 +41,17 @@ def __setup_logger():
     
     root = logging.getLogger()
     logger = logging.getLogger("fdk")
+
+    ch = logging.StreamHandler(sys.stderr)
+    formatter = RequestFormatter(
+        '%(fn_request_id)s - '
+        '%(name)s - '
+        '%(levelname)s - '
+        '%(message)s'
+    )
+    ch.setFormatter(formatter)
+    logger.addHandler(ch)
+
     if fdk_debug:
         root.setLevel(logging.DEBUG)
         logger.setLevel(logging.DEBUG)


### PR DESCRIPTION
Proposed fix for #114 by:
1. Setting the root logger to debug only when fdk itself is running in debug mode.
2. Move the `StreamHandler` to the fdk logger to play nice with apps using fdk and the root logger.